### PR TITLE
Fix for Logstash error when receiving event hub health check

### DIFF
--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/HealthCheck/EventHubLoggingHealthClient.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/HealthCheck/EventHubLoggingHealthClient.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 using UKHO.ExchangeSetService.Common.Configuration;
 using UKHO.ExchangeSetService.Common.Logging;
 
@@ -31,7 +32,10 @@ namespace UKHO.ExchangeSetService.Common.HealthCheck
 
             try
             {
-                await eventHubClient.SendAsync(new EventData(Encoding.UTF8.GetBytes(EventIds.EventHubLoggingEventDataForHealthCheck.ToEventId() + " of Event Hub")));
+                var jsonEventId = JsonConvert.SerializeObject(EventIds.EventHubLoggingEventDataForHealthCheck.ToEventId());
+
+                await eventHubClient.SendAsync(new EventData(Encoding.UTF8.GetBytes(jsonEventId)));
+
                 return HealthCheckResult.Healthy("Event hub is healthy");
             }
             catch (Exception ex)


### PR DESCRIPTION
Logstash is being "spammed" with the following errors from ESS:
```
[ERROR][logstash.codecs.json     ] JSON parse error, original data now in message field
{:error=>#<LogStash::Json::ParserError:
Unrecognized token 'EventHubLoggingEventDataForHealthCheck': was expecting ('true', 'false' or 'null')
```