### PR TITLE
ABZ - Return next url from FSS search response even when no entries are returned

### DIFF
--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/Helpers/FileShareService.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/Helpers/FileShareService.cs
@@ -151,7 +151,7 @@ namespace UKHO.ExchangeSetService.Common.Helpers
 
                         if (httpResponse.IsSuccessStatusCode)
                         {
-                            uri = await SelectLatestPublishedDateBatch(cacheProductsNotFound, internalSearchBatchResponse, uri, httpResponse, productList, message, cancellationTokenSource, cancellationToken, exchangeSetRootPath);
+                            uri = await SelectLatestPublishedDateBatch(cacheProductsNotFound, internalSearchBatchResponse, httpResponse, productList, message, cancellationTokenSource, cancellationToken, exchangeSetRootPath);
                         }
                         else
                         {
@@ -236,7 +236,7 @@ namespace UKHO.ExchangeSetService.Common.Helpers
             }
         }
 
-        private async Task<string> SelectLatestPublishedDateBatch(List<Products> products, SearchBatchResponse internalSearchBatchResponse, string uri, HttpResponseMessage httpResponse, List<string> productList, SalesCatalogueServiceResponseQueueMessage message, CancellationTokenSource cancellationTokenSource, CancellationToken cancellationToken, string exchangeSetRootPath)
+        private async Task<string> SelectLatestPublishedDateBatch(List<Products> products, SearchBatchResponse internalSearchBatchResponse, HttpResponseMessage httpResponse, List<string> productList, SalesCatalogueServiceResponseQueueMessage message, CancellationTokenSource cancellationTokenSource, CancellationToken cancellationToken, string exchangeSetRootPath)
         {
             SearchBatchResponse searchBatchResponse = await SearchBatchResponse(httpResponse);
             foreach (var item in searchBatchResponse.Entries)
@@ -256,10 +256,9 @@ namespace UKHO.ExchangeSetService.Common.Helpers
                         await CheckProductOrCancellationData(internalSearchBatchResponse, productList, item, productItem, updateNumber, compareProducts, message, cancellationTokenSource, cancellationToken, exchangeSetRootPath);
                     }
                 }
-                uri = searchBatchResponse.Links.Next?.Href;
             }
 
-            return uri;
+            return searchBatchResponse.Links?.Next?.Href;
         }
 
         private async Task CheckProductOrCancellationData(SearchBatchResponse internalSearchBatchResponse, List<string> productList, BatchDetail item, Products productItem, string updateNumber, string compareProducts, SalesCatalogueServiceResponseQueueMessage message, CancellationTokenSource cancellationTokenSource, CancellationToken cancellationToken, string exchangeSetRootPath)

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/Models/FileShareService/Response/SearchBatchResponse.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/Models/FileShareService/Response/SearchBatchResponse.cs
@@ -11,7 +11,7 @@ namespace UKHO.ExchangeSetService.Common.Models.FileShareService.Response
 
         public List<BatchDetail> Entries { get; set; }
 
-        [JsonProperty("_Links")]
+        [JsonProperty("_links")]
         public PagingLinks Links { get; set; }
 
         [JsonIgnore]

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/Models/FileShareService/Response/SearchBatchResponse.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/Models/FileShareService/Response/SearchBatchResponse.cs
@@ -11,7 +11,7 @@ namespace UKHO.ExchangeSetService.Common.Models.FileShareService.Response
 
         public List<BatchDetail> Entries { get; set; }
 
-        [JsonProperty("_links")]
+        [JsonProperty("_Links")]
         public PagingLinks Links { get; set; }
 
         [JsonIgnore]


### PR DESCRIPTION
When zero batches are returned, ensure the 'next' url (which is null/missing) is returned to stop endless looping.

Endless looping will only occur when some of the requested products are loaded from cache before the remaining products are requested from FSS. I think this explains why looping is occurring for some batches and not others.

Example FSS response payload for reference only

{
  "count": 0,
  "total": 0,
  "entries": [],
  "_Links": {
    "self": {
      "href": "/batch?limit=100&start=0&$filter=BusinessUnit%20eq%20%27ADDS%27%20and%20%24batch%28ProductCode%29%20eq%20%27AVCS%27%20and%20%20%28%28%24batch%28CellName%29%20eq%20%27HR600M3A%27%20and%20%24batch%28EditionNumber%29%20eq%20%271%27%20and%20%28%28%24batch%28UpdateNumber%29%20eq%20%271%27%20%29%29%20or%20%28%24batch%28CellName%29%20eq%20%27HR600M3A%27%20and%20%24batch%28EditionNumber%29%20eq%20%270%27%20and%20%24batch%28UpdateNumber%29%20eq%20%271%27%20%29%29%29"
    }
  }
}