### PR TITLE
ABZU-69611-Implment degraded health check

### DIFF
--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API/Program.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API/Program.cs
@@ -179,6 +179,7 @@ namespace UKHO.ExchangeSetService.API
             builder.Services.AddSingleton<ISmallExchangeSetInstance, SmallExchangeSetInstance>();
             builder.Services.AddSingleton<IMediumExchangeSetInstance, MediumExchangeSetInstance>();
             builder.Services.AddSingleton<ILargeExchangeSetInstance, LargeExchangeSetInstance>();
+            builder.Services.AddScoped<IAzureWebJobsHealthCheckHttpClient, AzureWebJobsHealthCheckHttpClient>();
             builder.Services.AddScoped<IAzureWebJobsHealthCheckClient, AzureWebJobsHealthCheckClient>();
             builder.Services.AddScoped<IAzureWebJobsHealthCheckService, AzureWebJobsHealthCheckService>();
             builder.Services.AddSingleton<IWebJobsAccessKeyProvider>(s => new WebJobsAccessKeyProvider(builder.Configuration));

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common.UnitTests/HealthCheck/AzureWebJobsHealthCheckClientTest.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common.UnitTests/HealthCheck/AzureWebJobsHealthCheckClientTest.cs
@@ -1,0 +1,218 @@
+﻿using FakeItEasy;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using NUnit.Framework;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using UKHO.ExchangeSetService.Common.HealthCheck;
+
+namespace UKHO.ExchangeSetService.Common.UnitTests.HealthCheck
+{
+    public class AzureWebJobsHealthCheckClientTest
+    {
+        private IAzureWebJobsHealthCheckHttpClient fakeAzureWebJobsHealthCheckHttpClient;
+        private AzureWebJobsHealthCheckClient azureWebJobsHealthCheckClient;
+
+        private static readonly WebJobDetails[] OneJobOneInstance =
+        {
+            new() { ExchangeSetType = "small", Instance = 1 }
+        };
+
+        private static readonly WebJobDetails[] ThreeJobsTwoInstances = 
+        {
+            new() { ExchangeSetType = "small", Instance = 1 },
+            new() { ExchangeSetType = "small", Instance = 2 },
+            new() { ExchangeSetType = "medium", Instance = 1 },
+            new() { ExchangeSetType = "medium", Instance = 2 },
+            new() { ExchangeSetType = "large", Instance = 1 },
+            new() { ExchangeSetType = "large", Instance = 2 }
+        };
+
+        private static readonly WebJobDetails[] ThreeJobsOneInstance =
+        {
+            new() { ExchangeSetType = "small", Instance = 1 },
+            new() { ExchangeSetType = "medium", Instance = 1 },
+            new() { ExchangeSetType = "large", Instance = 1 }
+        };
+
+        private static readonly WebJobDetails[] MultipleJobsMultipleInstances =
+        {
+            new() { ExchangeSetType = "small", Instance = 1 },
+            new() { ExchangeSetType = "small", Instance = 2 },
+            new() { ExchangeSetType = "medium", Instance = 1 },
+            new() { ExchangeSetType = "large", Instance = 1 },
+            new() { ExchangeSetType = "xlarge", Instance = 1 }
+        };
+
+        private static object[] _webJobsTestData =
+        {
+            new object[] { OneJobOneInstance },
+            new object[] { ThreeJobsTwoInstances },
+            new object[] { ThreeJobsOneInstance },
+            new object[] { MultipleJobsMultipleInstances }
+        };
+
+        [SetUp]
+        public void Setup()
+        {
+            this.fakeAzureWebJobsHealthCheckHttpClient = A.Fake<IAzureWebJobsHealthCheckHttpClient>();
+
+            azureWebJobsHealthCheckClient =
+                new AzureWebJobsHealthCheckClient(fakeAzureWebJobsHealthCheckHttpClient);
+        }
+
+        [TestCaseSource(nameof(_webJobsTestData))]
+        public async Task WhenAllInstancesAreHealthy_ThenReturnHealthy(WebJobDetails[] webJobs)
+        {   
+            A.CallTo(() => fakeAzureWebJobsHealthCheckHttpClient.CheckHealth(A<WebJobDetails>.Ignored))
+                .Returns(new HealthCheckResult(HealthStatus.Healthy, "Azure webjob is healthy"));
+
+            var result = await azureWebJobsHealthCheckClient.CheckAllWebJobsHealth(webJobs.ToList());
+
+            Assert.AreEqual(HealthCheckResult.Healthy().Status, result.Status);
+        }
+
+        [TestCaseSource(nameof(_webJobsTestData))]
+        public async Task WhenAllInstancesAreUnHealthy_ThenReturnUnHealthy(WebJobDetails[] webJobs)
+        {
+            A.CallTo(() => fakeAzureWebJobsHealthCheckHttpClient.CheckHealth(A<WebJobDetails>.Ignored))
+                .Returns(new HealthCheckResult(HealthStatus.Unhealthy, "Azure webjob is unhealthy"));
+
+            var result = await azureWebJobsHealthCheckClient.CheckAllWebJobsHealth(webJobs.ToList());
+
+            Assert.AreEqual(HealthCheckResult.Unhealthy().Status, result.Status);
+        }
+
+        [Test]
+        public async Task WhenHealthCheckThrowsException_ThenReturnUnHealthy()
+        {
+
+            A.CallTo(() => fakeAzureWebJobsHealthCheckHttpClient.CheckHealth(A<WebJobDetails>.Ignored))
+                .ThrowsAsync(new Exception(""));
+
+            var result = await azureWebJobsHealthCheckClient.CheckAllWebJobsHealth(OneJobOneInstance.ToList());
+
+            Assert.AreEqual(HealthCheckResult.Unhealthy().Status, result.Status);
+        }
+
+        [Test]
+        public async Task WhenAllInstancesOfOneTypeAreUnHealthy_ThenReturnUnhealthy()
+        {
+            var description1 = "Azure small webjob, instance 1 is unhealthy";
+            var description2 = "Azure small webjob, instance 2 is unhealthy";
+            var message1 = "error 1";
+            var message2 = "error 2";
+
+            var expected = new HealthCheckResult(HealthStatus.Unhealthy, 
+                string.Join(", ", description1, description2), 
+                new Exception(string.Join(", ", message1, message2)));
+
+            A.CallTo(() => fakeAzureWebJobsHealthCheckHttpClient.CheckHealth(
+                    A<WebJobDetails>.That.Matches(
+                        j => j.ExchangeSetType == "small" && j.Instance == 1)))
+                .Returns(Task.FromResult(new  HealthCheckResult(HealthStatus.Unhealthy, description1, new Exception(message1))));
+
+            A.CallTo(() => fakeAzureWebJobsHealthCheckHttpClient.CheckHealth(
+                    A<WebJobDetails>.That.Matches(
+                        j => j.ExchangeSetType == "small" && j.Instance == 2)))
+                .Returns(Task.FromResult(new HealthCheckResult(HealthStatus.Unhealthy, description2, new Exception(message2))));
+
+            A.CallTo(() => fakeAzureWebJobsHealthCheckHttpClient.CheckHealth(A<WebJobDetails>.That.Matches(j => j.ExchangeSetType != "small")))
+                .Returns(Task.FromResult(new HealthCheckResult(HealthStatus.Healthy,
+                    "Azure webjob is healthy")));
+
+            var result = await azureWebJobsHealthCheckClient.CheckAllWebJobsHealth(ThreeJobsTwoInstances.ToList());
+
+            Assert.AreEqual(expected.Status, result.Status);
+            Assert.AreEqual(expected.Description, result.Description);
+            Assert.AreEqual(expected.Exception?.Message, result.Exception?.Message);
+        }
+
+        [Test]
+        public async Task WhenOneInstanceIsUnhealthyAndOtherIsHealthy_ThenReturnDegraded()
+        {
+            var description1 = "Azure small webjob, instance 1 is unhealthy";
+            var message1 = "error 1";
+           
+            var expected = new HealthCheckResult(HealthStatus.Degraded,
+                description1, new Exception(message1));
+            
+            // Type: small, Instance: 1, Unhealthy
+            A.CallTo(() => fakeAzureWebJobsHealthCheckHttpClient.CheckHealth(
+                    A<WebJobDetails>.That.Matches(
+                        j => j.ExchangeSetType == "small" && j.Instance == 1)))
+                .Returns(Task.FromResult(new HealthCheckResult(HealthStatus.Unhealthy, description1, new Exception(message1))));
+
+            // Type: small, Instance: 2, Healthy
+            A.CallTo(() => fakeAzureWebJobsHealthCheckHttpClient.CheckHealth(
+                    A<WebJobDetails>.That.Matches(
+                        j => j.ExchangeSetType == "small" && j.Instance == 2)))
+                .Returns(Task.FromResult(new HealthCheckResult(HealthStatus.Healthy,
+                    "Azure webjob is healthy")));
+
+            // Rest are healthy
+            A.CallTo(() => fakeAzureWebJobsHealthCheckHttpClient.CheckHealth(
+                    A<WebJobDetails>.That.Matches(j => j.ExchangeSetType != "small")))
+                .Returns(Task.FromResult(new HealthCheckResult(HealthStatus.Healthy,
+                    "Azure webjob is healthy")));
+
+            var result = await azureWebJobsHealthCheckClient.CheckAllWebJobsHealth(ThreeJobsTwoInstances.ToList());
+
+            Assert.AreEqual(expected.Status, result.Status);
+            Assert.AreEqual(expected.Description, result.Description);
+            Assert.AreEqual(expected.Exception?.Message, result.Exception?.Message);
+        }
+
+        [Test]
+        public async Task WhenOneSmallInstanceIsUnhealthySecondIsHealthyAndAllMediumAreUnhealthy_ThenReturnUnhealthy()
+        {
+            var descriptionS1 = "Azure small webjob, instance 1 is unhealthy";
+            var messageS1 = "error 1";
+
+            var descriptionM1 = "Azure medium webjob, instance 1 is unhealthy";
+            var messageM1 = "error 1";
+
+            var descriptionM2 = "Azure medium webjob, instance 2 is unhealthy";
+            var messageM2 = "error 2";
+
+            var expected = new HealthCheckResult(HealthStatus.Unhealthy,
+                string.Join(", ", descriptionM1, descriptionM2, descriptionS1),
+                new Exception(string.Join(", ", messageM1, messageM2, messageS1)));
+
+            // Type: small, Instance: 1, Unhealthy
+            A.CallTo(() => fakeAzureWebJobsHealthCheckHttpClient.CheckHealth(
+                    A<WebJobDetails>.That.Matches(
+                        j => j.ExchangeSetType == "small" && j.Instance == 1)))
+                .Returns(Task.FromResult(new HealthCheckResult(HealthStatus.Unhealthy, descriptionS1, new Exception(messageS1))));
+
+            // Type: small, Instance: 2, Healthy
+            A.CallTo(() => fakeAzureWebJobsHealthCheckHttpClient.CheckHealth(
+                    A<WebJobDetails>.That.Matches(
+                        j => j.ExchangeSetType == "small" && j.Instance == 2)))
+                .Returns(Task.FromResult(new HealthCheckResult(HealthStatus.Healthy,
+                    "Azure webjob is healthy")));
+
+            // Type: medium, Instance: 1, Unhealthy
+            A.CallTo(() => fakeAzureWebJobsHealthCheckHttpClient.CheckHealth(
+                    A<WebJobDetails>.That.Matches(j => j.ExchangeSetType == "medium" && j.Instance == 1)))
+                .Returns(Task.FromResult(new HealthCheckResult(HealthStatus.Unhealthy, descriptionM1, new Exception(messageM1))));
+
+            // Type: medium, Instance: 2, Unhealthy
+            A.CallTo(() => fakeAzureWebJobsHealthCheckHttpClient.CheckHealth(
+                    A<WebJobDetails>.That.Matches(j => j.ExchangeSetType == "medium" && j.Instance == 2)))
+                .Returns(Task.FromResult(new HealthCheckResult(HealthStatus.Unhealthy, descriptionM2, new Exception(messageM2))));
+
+            // All Large are healthy
+            A.CallTo(() => fakeAzureWebJobsHealthCheckHttpClient.CheckHealth(
+                    A<WebJobDetails>.That.Matches(j => j.ExchangeSetType == "large")))
+                .Returns(Task.FromResult(new HealthCheckResult(HealthStatus.Healthy,
+                    "Azure webjob is healthy")));
+
+            var result = await azureWebJobsHealthCheckClient.CheckAllWebJobsHealth(ThreeJobsTwoInstances.ToList());
+
+            Assert.AreEqual(expected.Status, result.Status);
+            Assert.AreEqual(expected.Description, result.Description);
+            Assert.AreEqual(expected.Exception?.Message, result.Exception?.Message);
+        }
+    }
+}

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common.UnitTests/HealthCheck/AzureWebJobsHealthCheckTest.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common.UnitTests/HealthCheck/AzureWebJobsHealthCheckTest.cs
@@ -45,6 +45,16 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.HealthCheck
         }
 
         [Test]
+        public async Task WhenAzureWebJobStatusIsDegraded_ThenReturnDegraded()
+        {
+            A.CallTo(() => fakeAzureWebJobsHealthCheckService.CheckHealthAsync(A<CancellationToken>.Ignored)).Returns(new HealthCheckResult(HealthStatus.Degraded, "Azure webjob is unhealthy", new Exception("Azure webjob is unhealthy")));
+
+            var response = await azureWebJobsHealthCheck.CheckHealthAsync(new HealthCheckContext());
+            
+            Assert.AreEqual(HealthStatus.Degraded, response.Status);
+        }
+
+        [Test]
         public async Task WhenCheckHealthAsyncThrowException_ThenReturnUnhealthy()
         {
             A.CallTo(() => fakeAzureWebJobsHealthCheckService.CheckHealthAsync(A<CancellationToken>.Ignored)).Throws<Exception>();

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/HealthCheck/AzureWebJobsHealthCheck.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/HealthCheck/AzureWebJobsHealthCheck.cs
@@ -28,6 +28,10 @@ namespace UKHO.ExchangeSetService.Common.HealthCheck
                 {
                     logger.LogDebug(EventIds.AzureWebJobIsHealthy.ToEventId(), "Azure webjob is healthy");
                 }
+                else if (healthCheckResult.Status == HealthStatus.Degraded)
+                {
+                    logger.LogWarning(EventIds.AzureWebJobIsDegraded.ToEventId(), "Azure webjob is degraded");
+                }
                 else
                 {
                     logger.LogError(EventIds.AzureWebJobIsUnhealthy.ToEventId(), healthCheckResult.Exception, "Azure webjob is unhealthy with error {Message}", healthCheckResult.Exception.Message);

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/HealthCheck/AzureWebJobsHealthCheckHttpClient.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/HealthCheck/AzureWebJobsHealthCheckHttpClient.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Newtonsoft.Json;
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace UKHO.ExchangeSetService.Common.HealthCheck
+{
+    [ExcludeFromCodeCoverage]
+    public class AzureWebJobsHealthCheckHttpClient : IAzureWebJobsHealthCheckHttpClient
+    {
+        static HttpClient httpClient = new HttpClient();
+        private readonly IWebHostEnvironment webHostEnvironment;
+
+        public AzureWebJobsHealthCheckHttpClient(IWebHostEnvironment webHostEnvironment)
+        {
+            this.webHostEnvironment = webHostEnvironment;
+        }
+
+        public async Task<HealthCheckResult> CheckHealth(WebJobDetails webJobDetails)
+        {
+            try
+            {
+                using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, webJobDetails.WebJobUri);
+                httpClient.DefaultRequestHeaders.Accept.Clear();
+                httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", webJobDetails.UserPassword);
+                var response = await httpClient.SendAsync(httpRequestMessage, HttpCompletionOption.ResponseHeadersRead, CancellationToken.None);
+
+                if (response.StatusCode == HttpStatusCode.OK)
+                {
+                    var webJobHealthResponse = JsonConvert.DeserializeObject<dynamic>(await response.Content.ReadAsStringAsync());
+                    var webJobStatus = webJobHealthResponse?["status"];
+                    if (webJobStatus != "Running")
+                    {
+                        var webJobDetail = $"Webjob ess-{webHostEnvironment.EnvironmentName}-{webJobDetails.ExchangeSetType}-{webJobDetails.Instance} status is {webJobStatus}";
+                        return HealthCheckResult.Unhealthy("Azure webjob is unhealthy", new Exception(webJobDetail));
+                    }
+                }
+                else
+                {
+                    return HealthCheckResult.Unhealthy("Azure webjob is unhealthy", new Exception($"Webjob ess-{webHostEnvironment.EnvironmentName}-{webJobDetails.ExchangeSetType}-{webJobDetails.Instance} status code is {response.StatusCode}"));
+                }
+
+                return HealthCheckResult.Healthy();
+            }
+            catch (Exception ex)
+            {
+                return HealthCheckResult.Unhealthy("Azure webjob is unhealthy", new Exception(ex.Message));
+            }
+        }
+    }
+}

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/HealthCheck/IAzureWebJobsHealthCheckHttpClient.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/HealthCheck/IAzureWebJobsHealthCheckHttpClient.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Diagnostics.HealthChecks;
+using System.Threading.Tasks;
+
+namespace UKHO.ExchangeSetService.Common.HealthCheck
+{
+    public interface IAzureWebJobsHealthCheckHttpClient
+    {
+        public Task<HealthCheckResult> CheckHealth(WebJobDetails webJobDetails);
+    }
+}

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/Logging/EventIds.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/Logging/EventIds.cs
@@ -4,7 +4,7 @@ namespace UKHO.ExchangeSetService.Common.Logging
 {
     public enum EventIds
     {
-        /*Event id range for ESS - 805000 to 805122 */
+        /*Event id range for ESS - 805000 to 805172 */
         /// <summary>
         /// 805000 - Request for sales catalogue service products sincedatetime endpoint is started.
         /// </summary>
@@ -692,7 +692,11 @@ namespace UKHO.ExchangeSetService.Common.Logging
         /// <summary>
         /// 805171 - ENC update csv file not created
         /// </summary>
-        ENCupdateCSVFileIsNotCreated = 805171
+        ENCupdateCSVFileIsNotCreated = 805171,
+        /// <summary>
+        /// 805172 - Azure web job for exchange set service is degraded.
+        /// </summary>
+        AzureWebJobIsDegraded = 805172
     }
 
     public static class EventIdExtensions


### PR DESCRIPTION
Updated fulfilment webjobs health check implementation. 
if one instance of the same type of job is healthy and other is unhealthy 
then return degraded health check status instead of unhealthy.