### PR TITLE
Feature/81679 Move FT Test Data Out To The AppSetting.json

### DIFF
--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/FunctionalTests/EssEndPointsScenariosWhenAioIsDisabled.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/FunctionalTests/EssEndPointsScenariosWhenAioIsDisabled.cs
@@ -31,9 +31,7 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
         [Category("SmokeTest-AIODisabled")]
         public async Task WhenICallTheProductIdentifiersApiWithValidAndGB800001ProductAndAioIsDisabled_ThenACorrectResponseIsReturned()
         {
-            ProductIdentifierModel.ProductIdentifier = new List<string>() { "DE5NOBRK", "DE4NO18Q", "DE416080", "GB800001" };
-
-            var apiResponse = await ExchangeSetApiClient.GetProductIdentifiersDataAsync(ProductIdentifierModel.ProductIdentifier, accessToken: EssJwtToken);
+            var apiResponse = await ExchangeSetApiClient.GetProductIdentifiersDataAsync(Datahelper.GetAioProductIdentifierData(), accessToken: EssJwtToken);
             Assert.AreEqual(200, (int)apiResponse.StatusCode, $"Incorrect status code is returned {apiResponse.StatusCode}, instead of the expected status 200.");
 
             //verify model structure
@@ -52,7 +50,7 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
             //Check RequestedProductsNotInExchangeSet is not empty
             Assert.IsNotEmpty(apiResponseData.RequestedProductsNotInExchangeSet, "Response body returns Empty for RequestedProductsNotInExchangeSet, instead of Not Empty");
             
-            Assert.AreEqual("GB800001", apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName, $"Exchange set returned Product Name {apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName}, instead of expected Product Name 'GB800001'");
+            Assert.AreEqual(Config.AIOConfig.AioCellName, apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName, $"Exchange set returned Product Name {apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName}, instead of expected Product Name 'GB800001'");
             Assert.AreEqual("invalidProduct", apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().Reason, $"Exchange set returned Reason {apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().Reason}, instead of expected Reason 'invalidProduct'");
 
         }
@@ -63,8 +61,8 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
         {
             List<ProductVersionModel> ProductVersiondata = new();
 
-            ProductVersiondata.Add(Datahelper.GetProductVersionModelData("DE416080", 9, 1));
-            ProductVersiondata.Add(Datahelper.GetProductVersionModelData("GB800001", 1, 0));
+            ProductVersiondata.Add(Datahelper.GetProductVersionModelData(Config.AIOConfig.EncCellName, Config.AIOConfig.EncEditionNumber, Config.AIOConfig.EncUpdateNumber-1));
+            ProductVersiondata.Add(Datahelper.GetProductVersionModelData(Config.AIOConfig.AioCellName, Config.AIOConfig.AioEditionNumber, Config.AIOConfig.AioEditionNumber));
 
             var apiResponse = await ExchangeSetApiClient.GetProductVersionsAsync(ProductVersiondata, accessToken: EssJwtToken);
             Assert.AreEqual(200, (int)apiResponse.StatusCode, $"Incorrect status code {apiResponse.StatusCode} is returned, instead of the expected 200.");
@@ -74,7 +72,7 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
 
             var apiResponseData = await apiResponse.ReadAsTypeAsync<ExchangeSetResponseModel>();
 
-            Assert.AreEqual("GB800001", apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().ProductName, $"Exchange set returned Product Name {apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().ProductName}, instead of expected Product Name 'GB800001'");
+            Assert.AreEqual(Config.AIOConfig.AioCellName, apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().ProductName, $"Exchange set returned Product Name {apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().ProductName}, instead of expected Product Name 'GB800001'");
             Assert.AreEqual("invalidProduct", apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().Reason, $"Exchange set returned Reason {apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().Reason}, instead of expected Reason 'invalidProduct'");
 
         }
@@ -83,9 +81,7 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
         [Category("SmokeTest-AIODisabled")]
         public async Task WhenICallTheProductIdentifiersApiWithOnlyGB800001ProductAndAioIsDisabled_ThenACorrectResponseIsReturned()
         {
-            ProductIdentifierModel.ProductIdentifier = new List<string>() { "GB800001" };
-
-            var apiResponse = await ExchangeSetApiClient.GetProductIdentifiersDataAsync(ProductIdentifierModel.ProductIdentifier, accessToken: EssJwtToken);
+            var apiResponse = await ExchangeSetApiClient.GetProductIdentifiersDataAsync(Datahelper.GetProductIdentifiersForAioOnly(), accessToken: EssJwtToken);
             Assert.AreEqual(200, (int)apiResponse.StatusCode, $"Incorrect status code is returned {apiResponse.StatusCode}, instead of the expected status 200.");
 
             //verify model structure
@@ -104,7 +100,7 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
             //Check RequestedProductsNotInExchangeSet is not empty
             Assert.IsNotEmpty(apiResponseData.RequestedProductsNotInExchangeSet, "Response body returns Empty for RequestedProductsNotInExchangeSet, instead of Not Empty");
 
-            Assert.AreEqual("GB800001", apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName, $"Exchange set returned Product Name {apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName}, instead of expected Product Name 'GB800001'");
+            Assert.AreEqual(Config.AIOConfig.AioCellName, apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName, $"Exchange set returned Product Name {apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName}, instead of expected Product Name 'GB800001'");
             Assert.AreEqual("invalidProduct", apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().Reason, $"Exchange set returned Reason {apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().Reason}, instead of expected Reason 'invalidProduct'");
 
         }
@@ -115,7 +111,7 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
         {
             List<ProductVersionModel> ProductVersiondata = new();
 
-            ProductVersiondata.Add(Datahelper.GetProductVersionModelData("GB800001", 1, 0));
+            ProductVersiondata.Add(Datahelper.GetProductVersionModelData(Config.AIOConfig.AioCellName, Config.AIOConfig.AioEditionNumber, Config.AIOConfig.AioUpdateNumber));
 
             var apiResponse = await ExchangeSetApiClient.GetProductVersionsAsync(ProductVersiondata, accessToken: EssJwtToken);
             Assert.AreEqual(200, (int)apiResponse.StatusCode, $"Incorrect status code {apiResponse.StatusCode} is returned, instead of the expected 200.");
@@ -125,7 +121,7 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
 
             var apiResponseData = await apiResponse.ReadAsTypeAsync<ExchangeSetResponseModel>();
 
-            Assert.AreEqual("GB800001", apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().ProductName, $"Exchange set returned Product Name {apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().ProductName}, instead of expected Product Name 'GB800001'");
+            Assert.AreEqual(Config.AIOConfig.AioCellName, apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().ProductName, $"Exchange set returned Product Name {apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().ProductName}, instead of expected Product Name 'GB800001'");
             Assert.AreEqual("invalidProduct", apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().Reason, $"Exchange set returned Reason {apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().Reason}, instead of expected Reason 'invalidProduct'");
 
         }
@@ -153,7 +149,7 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
             //Check RequestedProductsNotInExchangeSet is not empty
             Assert.IsNotEmpty(apiResponseData.RequestedProductsNotInExchangeSet, "Response body returns Empty for RequestedProductsNotInExchangeSet, instead of Not Empty");
 
-            Assert.AreEqual("GB800001", apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName, $"Exchange set returned Product Name {apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName}, instead of expected Product Name 'GB800001'");
+            Assert.AreEqual(Config.AIOConfig.AioCellName, apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName, $"Exchange set returned Product Name {apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName}, instead of expected Product Name 'GB800001'");
             Assert.AreEqual("invalidProduct", apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().Reason, $"Exchange set returned Reason {apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().Reason}, instead of expected Reason 'invalidProduct'");
 
         }

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/FunctionalTests/EssEndPointsScenariosWhenAioIsEnabled.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/FunctionalTests/EssEndPointsScenariosWhenAioIsEnabled.cs
@@ -63,8 +63,6 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
             //Check RequestedProductsNotInExchangeSet is empty
             Assert.IsEmpty(apiResponseData.RequestedProductsNotInExchangeSet, "Response body returns Not Empty for RequestedProductsNotInExchangeSet, instead of Empty");
 
-            ProductIdentifierModel.ProductIdentifier.Clear();
-
         }
 
         [Test]
@@ -141,7 +139,6 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
             Assert.AreEqual("ABCDEFGH", apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName, $"Exchange set returned Product Name {apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName}, instead of expected Product Name 'ABCDEFGH'");
             Assert.AreEqual("invalidProduct", apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().Reason, $"Exchange set returned Reason {apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().Reason}, instead of expected Reason 'invalidProduct'");
 
-            ProductIdentifierModel.ProductIdentifier.Clear();
         }
 
         [Test]
@@ -205,8 +202,6 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
             //Check RequestedProductsNotInExchangeSet is empty
             Assert.IsEmpty(apiResponseData.RequestedProductsNotInExchangeSet, "Response body returns Not Empty for RequestedProductsNotInExchangeSet, instead of Empty");
 
-            ProductIdentifierModel.ProductIdentifier.Clear();
-
         }
 
         [Test]
@@ -262,9 +257,6 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
 
             //Check RequestedProductsNotInExchangeSet is empty
             Assert.IsEmpty(apiResponseData.RequestedProductsNotInExchangeSet, "Response body returns Not Empty for RequestedProductsNotInExchangeSet, instead of Empty");
-
-            ProductIdentifierModel.ProductIdentifier.Clear();
-
         }
 
         [Test]
@@ -323,8 +315,6 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
 
             Assert.AreEqual(Config.AIOConfig.AioCellName, apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName, $"Exchange set returned Product Name {apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName}, instead of expected Product Name 'GB800001'");
             Assert.AreEqual("duplicateProduct", apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().Reason, $"Exchange set returned Reason {apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().Reason}, instead of expected Reason 'duplicateProduct'");
-
-            ProductIdentifierModel.ProductIdentifier.Clear();
 
         }
 
@@ -389,8 +379,7 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
 
             Assert.AreEqual(Config.AIOConfig.InvalidAioCellName, apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName, $"Exchange set returned Product Name {apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName}, instead of expected Product Name 'GZ800112'");
             Assert.AreEqual("invalidProduct", apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().Reason, $"Exchange set returned Reason {apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().Reason}, instead of expected Reason 'invalidProduct'");
-
-            ProductIdentifierModel.ProductIdentifier.Clear();
+            
         }
 
         [Test]

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/FunctionalTests/EssEndPointsScenariosWhenAioIsEnabled.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/FunctionalTests/EssEndPointsScenariosWhenAioIsEnabled.cs
@@ -35,9 +35,7 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
         [Category("SmokeTest-AIOEnabled")]
         public async Task WhenICallTheProductIdentifiersApiWithValidAndGB800001ProductAndAioIsEnabled_ThenACorrectResponseIsReturned()
         {
-            ProductIdentifierModel.ProductIdentifier = new List<string>() { "DE5NOBRK", "DE4NO18Q", "DE416080", "GB800001" };
-
-            var apiResponse = await ExchangeSetApiClient.GetProductIdentifiersDataAsync(ProductIdentifierModel.ProductIdentifier, accessToken: EssJwtToken);
+            var apiResponse = await ExchangeSetApiClient.GetProductIdentifiersDataAsync(Datahelper.GetAioProductIdentifierData(), accessToken: EssJwtToken);
             Assert.AreEqual(200, (int)apiResponse.StatusCode, $"Incorrect status code is returned {apiResponse.StatusCode}, instead of the expected status 200.");
 
             //verify model structure
@@ -75,9 +73,8 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
         {
             List<ProductVersionModel> ProductVersiondata = new List<ProductVersionModel>();
 
-            ProductVersiondata.Add(Datahelper.GetProductVersionModelData("DE416080", 9, 1));
-            ProductVersiondata.Add(Datahelper.GetProductVersionModelData("CA479226", 4, 6));
-            ProductVersiondata.Add(Datahelper.GetProductVersionModelData("GB800001", 1, 0));
+            ProductVersiondata.Add(Datahelper.GetProductVersionModelData(Config.AIOConfig.EncCellName, Config.AIOConfig.EncEditionNumber, 1));
+            ProductVersiondata.Add(Datahelper.GetProductVersionModelData(Config.AIOConfig.AioCellName, Config.AIOConfig.AioEditionNumber, 0));
 
             var apiResponse = await ExchangeSetApiClient.GetProductVersionsAsync(ProductVersiondata, accessToken: EssJwtToken);
             Assert.AreEqual(200, (int)apiResponse.StatusCode, $"Incorrect status code {apiResponse.StatusCode} is returned, instead of the expected 200.");
@@ -113,9 +110,7 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
         [Category("SmokeTest-AIOEnabled")]
         public async Task WhenICallTheProductIdentifiersApiWithValidAndGB800001AndAnInvalidProductAndAioIsEnabled_ThenACorrectResponseIsReturned()
         {
-            ProductIdentifierModel.ProductIdentifier = new List<string>() { "DE5NOBRK", "DE4NO18Q", "DE416080", "GB800001", "ABCDEFGH" };
-
-            var apiResponse = await ExchangeSetApiClient.GetProductIdentifiersDataAsync(ProductIdentifierModel.ProductIdentifier, accessToken: EssJwtToken);
+            var apiResponse = await ExchangeSetApiClient.GetProductIdentifiersDataAsync(Datahelper.GetAioProductIdentifierAndInvalidData(), accessToken: EssJwtToken);
             Assert.AreEqual(200, (int)apiResponse.StatusCode, $"Incorrect status code is returned {apiResponse.StatusCode}, instead of the expected status 200.");
 
             //verify model structure
@@ -155,9 +150,9 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
         {
             List<ProductVersionModel> ProductVersiondata = new List<ProductVersionModel>();
 
-            ProductVersiondata.Add(Datahelper.GetProductVersionModelData("CA479226", 4, 6));
-            ProductVersiondata.Add(Datahelper.GetProductVersionModelData("US2ARCGD", 1, 5));
-            ProductVersiondata.Add(Datahelper.GetProductVersionModelData("GB800001", 4, 6));
+            ProductVersiondata.Add(Datahelper.GetProductVersionModelData(Config.AIOConfig.EncCellName, Config.AIOConfig.EncEditionNumber, 1));
+            ProductVersiondata.Add(Datahelper.GetProductVersionModelData(Config.AIOConfig.InvalidEncCellName, 1, 5));
+            ProductVersiondata.Add(Datahelper.GetProductVersionModelData(Config.AIOConfig.AioCellName, Config.AIOConfig.AioEditionNumber, 6));
 
             var apiResponse = await ExchangeSetApiClient.GetProductVersionsAsync(ProductVersiondata, accessToken: EssJwtToken);
             Assert.AreEqual(200, (int)apiResponse.StatusCode, $"Incorrect status code {apiResponse.StatusCode} is returned, instead of the expected 200.");
@@ -170,7 +165,7 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
             //Check RequestedProductsNotInExchangeSet is not empty
             Assert.IsNotEmpty(apiResponseData.RequestedProductsNotInExchangeSet, "Response body returns Empty for RequestedProductsNotInExchangeSet, instead of Not Empty");
 
-            Assert.AreEqual("US2ARCGD", apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName, $"Exchange set returned Product Name {apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName}, instead of expected Product Name 'US2ARCGD'");
+            Assert.AreEqual(Config.AIOConfig.InvalidEncCellName, apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName, $"Exchange set returned Product Name {apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName}, instead of expected Product Name 'US2ARCGD'");
             Assert.AreEqual("invalidProduct", apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().Reason, $"Exchange set returned Reason {apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().Reason}, instead of expected Reason 'invalidProduct'");
 
             ProductVersiondata.Clear();
@@ -182,9 +177,7 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
 
         public async Task WhenICallTheProductIdentifiersApiWithValidEncAndNoAioProductAndAioIsEnabled_ThenACorrectResponseIsReturned()
         {
-            ProductIdentifierModel.ProductIdentifier = new List<string>() { "DE5NOBRK", "DE4NO18Q", "DE416080" };
-
-            var apiResponse = await ExchangeSetApiClient.GetProductIdentifiersDataAsync(ProductIdentifierModel.ProductIdentifier, accessToken: EssJwtToken);
+            var apiResponse = await ExchangeSetApiClient.GetProductIdentifiersDataAsync(Datahelper.GetProductIdentifierData(), accessToken: EssJwtToken);
             Assert.AreEqual(200, (int)apiResponse.StatusCode, $"Incorrect status code is returned {apiResponse.StatusCode}, instead of the expected status 200.");
 
             //verify model structure
@@ -222,8 +215,7 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
         {
             List<ProductVersionModel> ProductVersiondata = new List<ProductVersionModel>();
 
-            ProductVersiondata.Add(Datahelper.GetProductVersionModelData("DE416080", 9, 1));
-            ProductVersiondata.Add(Datahelper.GetProductVersionModelData("CA479226", 4, 6));
+            ProductVersiondata.Add(Datahelper.GetProductVersionModelData(Config.AIOConfig.EncCellName, 9, 1));
 
             var apiResponse = await ExchangeSetApiClient.GetProductVersionsAsync(ProductVersiondata, accessToken: EssJwtToken);
             Assert.AreEqual(200, (int)apiResponse.StatusCode, $"Incorrect status code {apiResponse.StatusCode} is returned, instead of the expected 200.");
@@ -243,9 +235,7 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
         [Category("SmokeTest-AIOEnabled")]
         public async Task WhenICallTheProductIdentifiersApiWithOnlyAioProductAndAioIsEnabled_ThenACorrectResponseIsReturned()
         {
-            ProductIdentifierModel.ProductIdentifier = new List<string>() { "GB800001" };
-
-            var apiResponse = await ExchangeSetApiClient.GetProductIdentifiersDataAsync(ProductIdentifierModel.ProductIdentifier, accessToken: EssJwtToken);
+            var apiResponse = await ExchangeSetApiClient.GetProductIdentifiersDataAsync(Datahelper.GetProductIdentifiersForAioOnly(), accessToken: EssJwtToken);
             Assert.AreEqual(200, (int)apiResponse.StatusCode, $"Incorrect status code is returned {apiResponse.StatusCode}, instead of the expected status 200.");
 
             //verify model structure
@@ -283,7 +273,7 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
         {
             List<ProductVersionModel> ProductVersiondata = new List<ProductVersionModel>();
 
-            ProductVersiondata.Add(Datahelper.GetProductVersionModelData("GB800001", 1, 0));
+            ProductVersiondata.Add(Datahelper.GetProductVersionModelData(Config.AIOConfig.AioCellName, 1, 0));
 
             var apiResponse = await ExchangeSetApiClient.GetProductVersionsAsync(ProductVersiondata, accessToken: EssJwtToken);
             Assert.AreEqual(200, (int)apiResponse.StatusCode, $"Incorrect status code {apiResponse.StatusCode} is returned, instead of the expected 200.");
@@ -303,9 +293,7 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
         [Category("SmokeTest-AIOEnabled")]
         public async Task WhenICallTheProductIdentifiersApiWithValidEncAndDuplicateAioProductAndAioIsEnabled_ThenACorrectResponseIsReturned()
         {
-            ProductIdentifierModel.ProductIdentifier = new List<string>() { "DE416080", "GB800001", "GB800001" };
-
-            var apiResponse = await ExchangeSetApiClient.GetProductIdentifiersDataAsync(ProductIdentifierModel.ProductIdentifier, accessToken: EssJwtToken);
+            var apiResponse = await ExchangeSetApiClient.GetProductIdentifiersDataAsync(Datahelper.GetDuplicateAioProductIdentifierData(), accessToken: EssJwtToken);
             Assert.AreEqual(200, (int)apiResponse.StatusCode, $"Incorrect status code is returned {apiResponse.StatusCode}, instead of the expected status 200.");
 
             //verify model structure
@@ -333,7 +321,7 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
             //Check RequestedProductsNotInExchangeSet is not empty
             Assert.IsNotEmpty(apiResponseData.RequestedProductsNotInExchangeSet, "Response body returns Empty for RequestedProductsNotInExchangeSet, instead of Not Empty");
 
-            Assert.AreEqual("GB800001", apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName, $"Exchange set returned Product Name {apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName}, instead of expected Product Name 'GB800001'");
+            Assert.AreEqual(Config.AIOConfig.AioCellName, apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName, $"Exchange set returned Product Name {apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName}, instead of expected Product Name 'GB800001'");
             Assert.AreEqual("duplicateProduct", apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().Reason, $"Exchange set returned Reason {apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().Reason}, instead of expected Reason 'duplicateProduct'");
 
             ProductIdentifierModel.ProductIdentifier.Clear();
@@ -346,9 +334,9 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
         {
             List<ProductVersionModel> ProductVersiondata = new List<ProductVersionModel>();
 
-            ProductVersiondata.Add(Datahelper.GetProductVersionModelData("DE416080", 9, 1));
-            ProductVersiondata.Add(Datahelper.GetProductVersionModelData("GB800001", 1, 0));
-            ProductVersiondata.Add(Datahelper.GetProductVersionModelData("GB800001", 1, 0));
+            ProductVersiondata.Add(Datahelper.GetProductVersionModelData(Config.AIOConfig.EncCellName, 9, 1));
+            ProductVersiondata.Add(Datahelper.GetProductVersionModelData(Config.AIOConfig.AioCellName, 1, 0));
+            ProductVersiondata.Add(Datahelper.GetProductVersionModelData(Config.AIOConfig.AioCellName, 1, 0));
 
             var apiResponse = await ExchangeSetApiClient.GetProductVersionsAsync(ProductVersiondata, accessToken: EssJwtToken);
             Assert.AreEqual(200, (int)apiResponse.StatusCode, $"Incorrect status code {apiResponse.StatusCode} is returned, instead of the expected 200.");
@@ -361,7 +349,7 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
             //Check RequestedProductsNotInExchangeSet is not empty
             Assert.IsNotEmpty(apiResponseData.RequestedProductsNotInExchangeSet, "Response body returns Empty for RequestedProductsNotInExchangeSet, instead of Not Empty");
 
-            Assert.AreEqual("GB800001", apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName, $"Exchange set returned Product Name {apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName}, instead of expected Product Name 'GB800001'");
+            Assert.AreEqual(Config.AIOConfig.AioCellName, apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName, $"Exchange set returned Product Name {apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName}, instead of expected Product Name 'GB800001'");
             Assert.AreEqual("duplicateProduct", apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().Reason, $"Exchange set returned Reason {apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().Reason}, instead of expected Reason 'duplicateProduct'");
 
             ProductVersiondata.Clear();
@@ -371,9 +359,7 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
         [Category("SmokeTest-AIOEnabled")]
         public async Task WhenICallTheProductIdentifiersApiWithValidEncProductAndAioCellWhichIsNotAvailableAndAioIsEnabled_ThenACorrectResponseIsReturned()
         {
-            ProductIdentifierModel.ProductIdentifier = new List<string>() { "DE5NOBRK", "DE4NO18Q", "DE416080", "GZ800112" };
-
-            var apiResponse = await ExchangeSetApiClient.GetProductIdentifiersDataAsync(ProductIdentifierModel.ProductIdentifier, accessToken: EssJwtToken);
+            var apiResponse = await ExchangeSetApiClient.GetProductIdentifiersDataAsync(Datahelper.GetAdditionalAioProductIdentifierData(), accessToken: EssJwtToken);
             Assert.AreEqual(200, (int)apiResponse.StatusCode, $"Incorrect status code is returned {apiResponse.StatusCode}, instead of the expected status 200.");
 
             //verify model structure
@@ -401,7 +387,7 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
             //Check RequestedProductsNotInExchangeSet is not empty
             Assert.IsNotEmpty(apiResponseData.RequestedProductsNotInExchangeSet, "Response body returns Empty for RequestedProductsNotInExchangeSet, instead of Not Empty");
 
-            Assert.AreEqual("GZ800112", apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName, $"Exchange set returned Product Name {apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName}, instead of expected Product Name 'GZ800112'");
+            Assert.AreEqual(Config.AIOConfig.InvalidAioCellName, apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName, $"Exchange set returned Product Name {apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName}, instead of expected Product Name 'GZ800112'");
             Assert.AreEqual("invalidProduct", apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().Reason, $"Exchange set returned Reason {apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().Reason}, instead of expected Reason 'invalidProduct'");
 
             ProductIdentifierModel.ProductIdentifier.Clear();
@@ -413,8 +399,8 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
         {
             List<ProductVersionModel> ProductVersiondata = new List<ProductVersionModel>();
 
-            ProductVersiondata.Add(Datahelper.GetProductVersionModelData("DE416080", 9, 1));
-            ProductVersiondata.Add(Datahelper.GetProductVersionModelData("GZ800112", 4, 6));
+            ProductVersiondata.Add(Datahelper.GetProductVersionModelData(Config.AIOConfig.EncCellName, 9, 1));
+            ProductVersiondata.Add(Datahelper.GetProductVersionModelData(Config.AIOConfig.InvalidAioCellName, 4, 6));
 
             var apiResponse = await ExchangeSetApiClient.GetProductVersionsAsync(ProductVersiondata, accessToken: EssJwtToken);
             Assert.AreEqual(200, (int)apiResponse.StatusCode, $"Incorrect status code {apiResponse.StatusCode} is returned, instead of the expected 200.");
@@ -444,7 +430,7 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
             //Check RequestedProductsNotInExchangeSet is empty
             Assert.IsNotEmpty(apiResponseData.RequestedProductsNotInExchangeSet, "Response body returns Empty for RequestedProductsNotInExchangeSet, instead of Not Empty");
 
-            Assert.AreEqual("GZ800112", apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName, $"Exchange set returned Product Name {apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName}, instead of expected Product Name 'GZ800112'");
+            Assert.AreEqual(Config.AIOConfig.InvalidAioCellName, apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName, $"Exchange set returned Product Name {apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName}, instead of expected Product Name 'GZ800112'");
             Assert.AreEqual("invalidProduct", apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().Reason, $"Exchange set returned Reason {apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().Reason}, instead of expected Reason 'invalidProduct'");
 
             ProductVersiondata.Clear();
@@ -482,7 +468,7 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
             //Check RequestedProductsNotInExchangeSet is not empty
             Assert.IsNotEmpty(apiResponseData.RequestedProductsNotInExchangeSet, "Response body returns Empty for RequestedProductsNotInExchangeSet, instead of Not Empty");
 
-            Assert.AreEqual("GZ800112", apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName, $"Exchange set returned Product Name {apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName}, instead of expected Product Name 'GZ800112'");
+            Assert.AreEqual(Config.AIOConfig.InvalidAioCellName, apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName, $"Exchange set returned Product Name {apiResponseData.RequestedProductsNotInExchangeSet.LastOrDefault().ProductName}, instead of expected Product Name 'GZ800112'");
             Assert.AreEqual("invalidProduct", apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().Reason, $"Exchange set returned Reason {apiResponseData.RequestedProductsNotInExchangeSet.FirstOrDefault().Reason}, instead of expected Reason 'invalidProduct'");
         }
 

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/FunctionalTests/ExchangeSetGenerateFilesForAioProductIdentifierWhenAioIsEnabled.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/FunctionalTests/ExchangeSetGenerateFilesForAioProductIdentifierWhenAioIsEnabled.cs
@@ -72,7 +72,7 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
                 string productName = product.ProductName;
                 int editionNumber = product.EditionNumber;
 
-                if (productName.Equals("GB800001"))
+                if (productName.Equals(Config.AIOConfig.AioCellName))
                 {
                     //Enc file download verification
                     foreach (var updateNumber in product.UpdateNumbers)

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/FunctionalTests/ExchangeSetGenerateFilesForAioProductVersionWhenAioIsEnabled.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/FunctionalTests/ExchangeSetGenerateFilesForAioProductVersionWhenAioIsEnabled.cs
@@ -25,7 +25,7 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
             FssApiClient = new FssApiClient();
             DataHelper = new DataHelper();
             ProductVersionData = new List<ProductVersionModel>();
-            ProductVersionData.Add(DataHelper.GetProductVersionModelData("GB800001", 31, 0));
+            ProductVersionData.Add(DataHelper.GetProductVersionModelData(Config.AIOConfig.AioCellName, Config.AIOConfig.AioEditionNumber, 0));
             ApiEssResponse = await ExchangeSetApiClient.GetProductVersionsAsync(ProductVersionData, accessToken: EssJwtToken);
             //Get the BatchId
             batchId = await ApiEssResponse.GetBatchId();
@@ -74,7 +74,7 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
                 string productName = product.ProductName;
                 int editionNumber = product.EditionNumber;
 
-                if (productName.Equals("GB800001"))
+                if (productName.Equals(Config.AIOConfig.AioCellName))
                 {
                     //Enc file download verification
                     foreach (var updateNumber in product.UpdateNumbers)

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/FunctionalTests/ExchangeSetGenerateFilesForEncAndAioProductIdentifierWhenAioIsEnabled.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/FunctionalTests/ExchangeSetGenerateFilesForEncAndAioProductIdentifierWhenAioIsEnabled.cs
@@ -71,7 +71,7 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
                 string productName = product.ProductName;
                 int editionNumber = product.EditionNumber;
 
-                if (productName.Equals("GB800001"))
+                if (productName.Equals(Config.AIOConfig.AioCellName))
                 {
                     //Enc file download verification
                     foreach (var updateNumber in product.UpdateNumbers)

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/FunctionalTests/ExchangeSetGenerateFilesForEncAndAioProductVersionWhenAioIsEnabled.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/FunctionalTests/ExchangeSetGenerateFilesForEncAndAioProductVersionWhenAioIsEnabled.cs
@@ -25,8 +25,8 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
             FssApiClient = new FssApiClient();
             DataHelper = new DataHelper();
             ProductVersionData = new List<ProductVersionModel>();
-            ProductVersionData.Add(DataHelper.GetProductVersionModelData("GB800001", 31, 0));
-            ProductVersionData.Add(DataHelper.GetProductVersionModelData("DE4NO18Q", 2, 0));
+            ProductVersionData.Add(DataHelper.GetProductVersionModelData(Config.AIOConfig.AioCellName, Config.AIOConfig.AioEditionNumber, 0));
+            ProductVersionData.Add(DataHelper.GetProductVersionModelData(Config.AIOConfig.EncCellName, Config.AIOConfig.EncEditionNumber, 0));
             ApiEssResponse = await ExchangeSetApiClient.GetProductVersionsAsync(ProductVersionData, accessToken: EssJwtToken);
             //Get the BatchId
             batchId = await ApiEssResponse.GetBatchId();
@@ -75,7 +75,7 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
                 string productName = product.ProductName;
                 int editionNumber = product.EditionNumber;
 
-                if (productName.Equals("GB800001"))
+                if (productName.Equals(Config.AIOConfig.AioCellName))
                 {
                     //Enc file download verification
                     foreach (var updateNumber in product.UpdateNumbers)

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/FunctionalTests/ExchangeSetGenerateFilesForLargeMediaAndAioProductIdentifierWhenAioIsEnabled.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/FunctionalTests/ExchangeSetGenerateFilesForLargeMediaAndAioProductIdentifierWhenAioIsEnabled.cs
@@ -69,7 +69,7 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
                 string productName = product.ProductName;
                 int editionNumber = product.EditionNumber;
 
-                if (productName.Equals("GB800001"))
+                if (productName.Equals(Config.AIOConfig.AioCellName))
                 {
                     //Enc file download verification
                     foreach (var updateNumber in product.UpdateNumbers)

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/FunctionalTests/ExchangeSetGeneratesProperZipForAioAndEmptyZipForV01X01WhenAioAndEncProductVersionAndAioIsEnabled.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/FunctionalTests/ExchangeSetGeneratesProperZipForAioAndEmptyZipForV01X01WhenAioAndEncProductVersionAndAioIsEnabled.cs
@@ -88,7 +88,7 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.FunctionalTests
                 string productName = product.ProductName;
                 int editionNumber = product.EditionNumber;
 
-                if (productName.Equals("GB800001"))
+                if (productName.Equals(Config.AIOConfig.AioCellName))
                 {
                     //Enc file download verification
                     foreach (var updateNumber in product.UpdateNumbers)

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/Helper/DataHelper.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/Helper/DataHelper.cs
@@ -65,5 +65,28 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.Helper
             return new List<string>() { "FR570300", "SE6IIFE1", "NO3B2020", "GB20486A", "RU3P0ZM0", "US5CN13M", "CA172005", "DE521900", "NZ300661", "KR676D03", "GZ800112" };
         }
 
+        public List<string> GetAioProductIdentifierData()
+        {
+            return new List<string>() { "DE5NOBRK", "DE4NO18Q", "DE416080", "GB800001" };
+
+        }
+
+        public List<string> GetAioProductIdentifierAndInvalidData()
+        {
+            return new List<string>() { "DE5NOBRK", "DE4NO18Q", "DE416080", "GB800001", "ABCDEFGH" };
+
+        }
+
+        public List<string> GetDuplicateAioProductIdentifierData()
+        {
+            return new List<string>() { "DE416080", "GB800001", "GB800001" };
+
+        }
+
+        public List<string> GetAdditionalAioProductIdentifierData()
+        {
+            return new List<string>() { "DE5NOBRK", "DE4NO18Q", "DE416080", "GZ800112" };
+
+        }
     }
 }

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/Helper/TestConfiguration.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/Helper/TestConfiguration.cs
@@ -99,6 +99,8 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.Helper
             public string EncCellName { get; set; }
             public int EncEditionNumber { get; set; }
             public int EncUpdateNumber { get; set; }
+            public string InvalidEncCellName { get; set; }
+            public string InvalidAioCellName { get; set; }
         }
 
         public TestConfiguration()

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/appsettings.json
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/appsettings.json
@@ -70,6 +70,8 @@
     "AioUpdateNumber": 59, ////The UpdateNumber here needs updating whenever QA data change happens
     "EncCellName": "DE416080",
     "EncEditionNumber": 9,
-    "EncUpdateNumber": 2 ////The UpdateNumber here needs updating whenever QA data change happens
+    "EncUpdateNumber": 2, ////The UpdateNumber here needs updating whenever QA data change happens
+    "InvalidEncCellName": "DE416080",
+    "InvalidAioCellName": "GZ800112"
   }
 }

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/appsettings.json
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/appsettings.json
@@ -71,7 +71,7 @@
     "EncCellName": "DE416080",
     "EncEditionNumber": 9,
     "EncUpdateNumber": 2, ////The UpdateNumber here needs updating whenever QA data change happens
-    "InvalidEncCellName": "DE416080",
+    "InvalidEncCellName": "US2ARCGD",
     "InvalidAioCellName": "GZ800112"
   }
 }


### PR DESCRIPTION
The test data has been moved to a single file either to the DataHelper.cs or AppSettings.JSON for all AIO FTs.