### PR TITLE
Add v2 to SOLAS APIM

### DIFF
--- a/Deployment/templates/continuous-deployment-apim-v2.yml
+++ b/Deployment/templates/continuous-deployment-apim-v2.yml
@@ -14,9 +14,17 @@ parameters:
     type: string
   - name: tfstateStorageAccountName
     type: string
+  # If true then set policy to rewrite new APIM links to old. If false then rewrite old to new.
+  - name: SetLinkRewriteNewToOld
+    type: boolean
+    default: true
+  # If true then use new tfplan naming convention.
+  - name: UseNewTfplanName
+    type: boolean
+    default: false
 
 steps:
-  - task: AzureKeyVault@1
+  - task: AzureKeyVault@2
     displayName: 'Read APIM terraform Variables'
     inputs:
       azureSubscription: "${{ parameters.AzureSubscription }}"
@@ -30,7 +38,7 @@ steps:
     inputs:
       targetType: filePath
       filePath: '$(Pipeline.Workspace)/terraformartifact/terraform_conditional_run_apim_v2.ps1'
-      arguments: '-deploymentResourceGroupName ${{ parameters.tfstateStorageAccountRG }} -deploymentStorageAccountName ${{ parameters.tfstateStorageAccountName }} -workSpace $(Environment) -continueEvenIfResourcesAreGettingDestroyed $${{ parameters.ContinueEvenIfResourcesAreGettingDestroyed }}'
+      arguments: '-deploymentResourceGroupName ${{ parameters.tfstateStorageAccountRG }} -deploymentStorageAccountName ${{ parameters.tfstateStorageAccountName }} -workSpace $(Environment) -continueEvenIfResourcesAreGettingDestroyed $${{ parameters.ContinueEvenIfResourcesAreGettingDestroyed }} -useNewTfplanName $${{ parameters.UseNewTfplanName }}'
     env:
       ARM_CLIENT_ID: $(TERRAFORM-CLIENT-ID)
       ARM_CLIENT_SECRET: $(TERRAFORM-CLIENT-SECRET)
@@ -38,7 +46,7 @@ steps:
       ARM_SUBSCRIPTION_ID: $(TERRAFORM-SUBSCRIPTION-ID)
       TF_VAR_apim_rg: ${{ parameters.APIMResourceGroup }}
       TF_VAR_apim_name: ${{ parameters.APIMServiceInstance }}
-      TF_VAR_apim_api_backend_url: $(EssApiUrl)
+      TF_VAR_apim_api_backend_url: $(SERVICE_DNS_URL)
       TF_VAR_client_credentials_tenant_id: $(AzureAdB2CConfiguration.TenantId)
       TF_VAR_client_credentials_scope: "$(AzureAdB2CConfiguration.ClientId)/.default"
       TF_VAR_b2c_token_issuer: "$(APIM_B2C_TOKEN_ISSUER)"
@@ -47,5 +55,9 @@ steps:
       TF_VAR_ess_ui_product_call_limit: $(essuiproductcalllimit)
       TF_VAR_ess_ui_product_call_renewal_period: $(essuiproductcallrenewalperiod)
       TF_VAR_ess_ui_product_daily_quota_limit: $(essuiproductdailyquotalimit)
-      TF_VAR_policy_rewrite_from_gateway: $(APIM_NEW_GATEWAY)
-      TF_VAR_policy_rewrite_to_gateway: $(APIM_OLD_GATEWAY)
+      ${{ if eq(parameters.SetLinkRewriteNewToOld, true) }}:
+        TF_VAR_policy_rewrite_from_gateway: $(APIM_NEW_GATEWAY)
+        TF_VAR_policy_rewrite_to_gateway: $(APIM_OLD_GATEWAY)
+      ${{ else }}:
+        TF_VAR_policy_rewrite_from_gateway: $(APIM_OLD_GATEWAY)
+        TF_VAR_policy_rewrite_to_gateway: $(APIM_NEW_GATEWAY)

--- a/Deployment/terraform_conditional_run_apim_v2.ps1
+++ b/Deployment/terraform_conditional_run_apim_v2.ps1
@@ -2,14 +2,19 @@ param (
     [Parameter(Mandatory = $true)] [string] $deploymentResourceGroupName,
     [Parameter(Mandatory = $true)] [string] $deploymentStorageAccountName,
     [Parameter(Mandatory = $true)] [string] $workSpace,
-    [Parameter(Mandatory = $true)] [boolean] $continueEvenIfResourcesAreGettingDestroyed
+    [Parameter(Mandatory = $true)] [boolean] $continueEvenIfResourcesAreGettingDestroyed,
+    [Parameter(Mandatory = $true)] [boolean] $useNewTfplanName
 )
 
 cd $env:AGENT_BUILDDIRECTORY/terraformartifact/src/Modules/APIM/
 
-Write-output "Executing terraform scripts for APIM deployment in $workSpace enviroment..."
+terraform --version
 
-terraform init -backend-config="resource_group_name=$deploymentResourceGroupName" -backend-config="storage_account_name=$deploymentStorageAccountName" -backend-config="key=terraform.ess.apim.deployment.v2.tfplan"
+Write-output "Executing terraform scripts for APIM deployment in $workSpace environment..."
+
+$backendConfigKey = $useNewTfplanName ? "terraform.deployment.apim.ess.v2.tfplan" : "terraform.ess.apim.deployment.v2.tfplan"
+Write-output "Using plan $backendConfigKey"
+terraform init -backend-config="resource_group_name=$deploymentResourceGroupName" -backend-config="storage_account_name=$deploymentStorageAccountName" -backend-config="key=$backendConfigKey"
 if ( !$? ) { echo "Something went wrong during terraform initialization"; throw "Error" }
 
 Write-output "Selecting workspace..."
@@ -26,7 +31,7 @@ terraform validate
 if ( !$? ) { echo "Something went wrong during terraform validation" ; throw "Error" }
 
 Write-output "Execute Terraform plan..."
-terraform plan -out "terraform.ess.apim.deployment.v2.tfplan" -var suffix=" v2" -var pathsuffix="-v2" | tee terraform_output.txt
+terraform plan -out "$backendConfigKey" -var suffix=" v2" -var pathsuffix="-v2" | tee terraform_output.txt
 if ( !$? ) { echo "Something went wrong during terraform plan" ; throw "Error" }
 
 $totalDestroyLines=(Get-Content -Path terraform_output.txt | Select-String -Pattern "destroy" -CaseSensitive |  where {$_ -ne ""}).length
@@ -43,5 +48,5 @@ if($totalDestroyLines -ge 2)
 }
 
 Write-output "Executing terraform apply..."
-terraform apply  "terraform.ess.apim.deployment.v2.tfplan"
+terraform apply "$backendConfigKey"
 if ( !$? ) { echo "Something went wrong during terraform apply" ; throw "Error" }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -745,6 +745,33 @@ stages:
                     SetLinkRewriteNewToOld: false
                     UseNewTfplanName: true
 
+      - deployment: QADeployApimSolas2
+        displayName: "QA - deploy SOLAS APIM for FSS UI"
+        environment: "Ess-Qa"
+        pool: $(DeploymentPool)
+        container: ${{variables.Container}}
+        workspace:
+          clean: all
+        variables:
+          - group: "ESS-Deployment-Variables-QA"
+          - group: "ESS-QA2-Variables"
+          - group: "ESS-QA-APIM-SOLAS-Variables"
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - template: Deployment/templates/continuous-deployment-apim-v2.yml
+                  parameters:
+                    ContinueEvenIfResourcesAreGettingDestroyed: ${{ parameters.ContinueEvenIfResourcesAreGettingDestroyed }}
+                    AzureSubscription: "UKHO-APIM-SOLAS-NonLive"
+                    TerraformKeyVault: $(APIM_SOLAS_TERRAFORM_KEYVAULT)
+                    APIMResourceGroup: $(APIM_SOLAS_RESOURCE_GROUP_NAME)
+                    APIMServiceInstance: $(APIM_SOLAS_SERVICE_NAME)
+                    tfstateStorageAccountRG: $(APIM_SOLAS_RESOURCE_GROUP_NAME)
+                    tfstateStorageAccountName: $(APIM_SOLAS_TFSTATE_STORAGE_ACCOUNT_NAME)
+                    SetLinkRewriteNewToOld: false
+                    UseNewTfplanName: true
+
       - deployment: QADeployApp
         dependsOn: [QADeployApimSolas]
         displayName: QA - deploy terraform and dotnet App
@@ -837,7 +864,9 @@ stages:
                     arguments: '-aiocells $(AioConfiguration.AioCells) -aioenabled $(AioConfiguration.AioEnabled) -resourcegroup $(RESOURCE_GROUP_NAME) -webappname $(WEB_APP_NAME) -fulfilmentwebappsname $(fulfilmentWebAppsName)'
 
       - deployment: QADeployApp2
-        dependsOn: QADeployApp
+        dependsOn:
+        - QADeployApp
+        - QADeployApimSolas2
         displayName: "QA - deploy terraform and dotnet App for FSS UI"
         environment: "Ess-Qa"
         pool: $(DeploymentPool)
@@ -936,6 +965,33 @@ stages:
                     SetLinkRewriteNewToOld: false
                     UseNewTfplanName: true
 
+      - deployment: LiveDeployApimSolas2
+        displayName: "Live - deploy SOLAS APIM for FSS UI"
+        environment: "Ess-Live"
+        pool: $(DeploymentPool)
+        container: ${{variables.Container}}
+        workspace:
+          clean: all
+        variables:
+          - group: "ESS-Deployment-Variables-LIVE"
+          - group: "ESS-Live2-Variables"
+          - group: "ESS-Live-APIM-SOLAS-Variables"
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - template: Deployment/templates/continuous-deployment-apim-v2.yml
+                  parameters:
+                    ContinueEvenIfResourcesAreGettingDestroyed: ${{ parameters.ContinueEvenIfResourcesAreGettingDestroyed }}
+                    AzureSubscription: "UKHO-APIM-SOLAS-Live"
+                    TerraformKeyVault: $(APIM_SOLAS_TERRAFORM_KEYVAULT)
+                    APIMResourceGroup: $(APIM_SOLAS_RESOURCE_GROUP_NAME)
+                    APIMServiceInstance: $(APIM_SOLAS_SERVICE_NAME)
+                    tfstateStorageAccountRG: $(APIM_SOLAS_RESOURCE_GROUP_NAME)
+                    tfstateStorageAccountName: $(APIM_SOLAS_TFSTATE_STORAGE_ACCOUNT_NAME)
+                    SetLinkRewriteNewToOld: false
+                    UseNewTfplanName: true
+
       - deployment: LiveDeployApp
         dependsOn: [LiveDeployApimSolas]
         displayName: Live - deploy terraform and dotnet App
@@ -971,7 +1027,9 @@ stages:
                     tfstateStorageAccountName: $(APIM_TFSTATE_STORAGE_ACCOUNT_NAME)
 
       - deployment: LiveDeployApp2
-        dependsOn: LiveDeployApp
+        dependsOn:
+        - LiveDeployApp
+        - LiveDeployApimSolas2
         displayName: "Live - deploy terraform and dotnet App for FSS UI"
         environment: "Ess-Live"
         pool: $(DeploymentPool)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -460,6 +460,33 @@ stages:
                     SetLinkRewriteNewToOld: false
                     UseNewTfplanName: true
 
+      - deployment: DevDeployApimSolas2
+        displayName: "Dev - deploy SOLAS APIM for FSS UI"
+        environment: "Ess-Dev"
+        pool: $(DeploymentPool)
+        container: ${{variables.Container}}
+        workspace:
+          clean: all
+        variables:
+          - group: "ESS-Deployment-Variables-DEV"
+          - group: "ESS-Dev2-Variables"
+          - group: "ESS-Dev-APIM-SOLAS-Variables"
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - template: Deployment/templates/continuous-deployment-apim-v2.yml
+                  parameters:
+                    ContinueEvenIfResourcesAreGettingDestroyed: ${{ parameters.ContinueEvenIfResourcesAreGettingDestroyed }}
+                    AzureSubscription: "UKHO-APIM-SOLAS-NonLive"
+                    TerraformKeyVault: $(APIM_SOLAS_TERRAFORM_KEYVAULT)
+                    APIMResourceGroup: $(APIM_SOLAS_RESOURCE_GROUP_NAME)
+                    APIMServiceInstance: $(APIM_SOLAS_SERVICE_NAME)
+                    tfstateStorageAccountRG: $(APIM_SOLAS_RESOURCE_GROUP_NAME)
+                    tfstateStorageAccountName: $(APIM_SOLAS_TFSTATE_STORAGE_ACCOUNT_NAME)
+                    SetLinkRewriteNewToOld: false
+                    UseNewTfplanName: true
+
       - deployment: DevDeployApp
         dependsOn: [DevDeployApimSolas]
         timeoutInMinutes: 75
@@ -574,6 +601,59 @@ stages:
                     scriptPath: "$(Build.SourcesDirectory)/terraformartifact/set_api_webjob_aio_feature_configuration.ps1"
                     arguments: '-aiocells $(AioConfiguration.AioCells_FT) -aioenabled $(AioConfiguration.AioEnabled) -resourcegroup $(RESOURCE_GROUP_NAME) -webappname $(WEB_APP_NAME) -fulfilmentwebappsname $(fulfilmentWebAppsName)'
 
+      - deployment: DevDeployApp2
+        dependsOn:
+        - DevDeployApp
+        - DevDeployApimSolas2
+        timeoutInMinutes: 75
+        displayName: "Dev - deploy terraform and dotnet App for FSS UI"
+        environment: "Ess-Dev"
+        pool: $(DeploymentPool)
+        container: ${{variables.Container}}
+        workspace:
+          clean: all
+        variables:
+          - group: "ESS-Deployment-Variables-DEV"
+          - group: "ESS-Dev2-Variables"
+          - name: "ESSAzureADConfiguration.ClientId"
+            value: $(ESSClientId)
+          - name: "ESSAzureADConfiguration.TenantId"
+            value: $(TenantId)
+          - name: "EssAuthorizationConfiguration.TenantId"
+            value: $(TenantId)
+          - name: "EssAuthorizationConfiguration.AutoTestClientId"
+            value: $(AutoTestClientId_Authed)
+          - name: "EssAuthorizationConfiguration.AutoTestClientSecret"
+            value: $(AutoTestClientSecret_Authed)
+          - name: "EssAuthorizationConfiguration.EssClientId"
+            value: $(ESSClientId)
+          - name: "EssAuthorizationConfiguration.AutoTestClientIdNoAuth"
+            value: $(AutoTestClientId_NoAuth)
+          - name: "EssAuthorizationConfiguration.AutoTestClientSecretNoAuth"
+            value: $(AutoTestClientSecret_NoAuth)
+          - name: "AzureAdB2CTestConfiguration.ClientSecret"
+            value: $(AUTOTEST-ESS-SECRET)
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - checkout: self
+                  submodules: recursive
+
+                - template: Deployment/templates/continuous-deployment-v2.yml
+                  parameters:
+                    ContinueEvenIfResourcesAreGettingDestroyed: ${{ parameters.ContinueEvenIfResourcesAreGettingDestroyed }}
+                    AzureSubscription: "Exchange-Set-Service-Dev-A-008-02"
+
+                - template: Deployment/templates/continuous-deployment-apim-v2.yml
+                  parameters:
+                    ContinueEvenIfResourcesAreGettingDestroyed: ${{ parameters.ContinueEvenIfResourcesAreGettingDestroyed }}
+                    AzureSubscription: "Fleet Manager Dev/Test"
+                    TerraformKeyVault: $(APIM_TERRAFORM_KEYVAULT)
+                    APIMResourceGroup: $(APIM_RESOURCE_GROUP_NAME)
+                    APIMServiceInstance: $(APIM_SERVICE_NAME)
+                    tfstateStorageAccountRG: $(APIM_TFSTATE_STORAGE_ACCOUNT_RG)
+                    tfstateStorageAccountName: $(APIM_TFSTATE_STORAGE_ACCOUNT_NAME)
 
   - stage: QCdeploy
     dependsOn:


### PR DESCRIPTION
#### PR Classification
New feature and configuration update for continuous deployment and Terraform integration.

#### PR Summary
Introduces new parameters and deployment stages to enhance link rewriting behavior and Terraform plan naming, along with updates to Azure Key Vault and environment variables.
- `continuous-deployment-apim-v2.yml`: Added `SetLinkRewriteNewToOld` and `UseNewTfplanName` parameters.
- `azure-pipelines.yml`: Added new deployment stages for Dev, QA, and Live environments.
- `terraform_conditional_run_apim_v2.ps1`: Updated to include `useNewTfplanName` parameter and adjusted backend configuration.
- Updated Azure Key Vault task version from `AzureKeyVault@1` to `AzureKeyVault@2`.
- Changed environment variable `TF_VAR_apim_api_backend_url` to use `$(SERVICE_DNS_URL)`.
