### PR TITLE
Refactor: Rename parameter to aioExchangeSetPath

### DIFF
--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/Helpers/FileShareService.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/Helpers/FileShareService.cs
@@ -574,13 +574,13 @@ namespace UKHO.ExchangeSetService.Common.Helpers
             }
         }
 
-        public async Task<bool> DownloadIhoCrtFile(string ihoCrtFilePath, string batchId, string exchangeSetRootPath, string correlationId)
+        public async Task<bool> DownloadIhoCrtFile(string ihoCrtFilePath, string batchId, string aioExchangeSetPath, string correlationId)
         {
             string payloadJson = string.Empty;
             var accessToken = await authFssTokenProvider.GetManagedIdentityAuthAsync(fileShareServiceConfig.Value.ResourceId);
             string fileName = fileShareServiceConfig.Value.IhoCrtFileName;
-            string filePath = Path.Combine(exchangeSetRootPath, fileName);
-            fileSystemHelper.CheckAndCreateFolder(exchangeSetRootPath);
+            string filePath = Path.Combine(aioExchangeSetPath, fileName);
+            fileSystemHelper.CheckAndCreateFolder(aioExchangeSetPath);
             string lineToWrite = string.Concat("File date: ", DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ssZ", CultureInfo.InvariantCulture));
             HttpResponseMessage httpIhoCrtFileResponse;
             httpIhoCrtFileResponse = await fileShareServiceClient.CallFileShareServiceApi(HttpMethod.Get, payloadJson, accessToken, ihoCrtFilePath, CancellationToken.None, correlationId);
@@ -607,13 +607,13 @@ namespace UKHO.ExchangeSetService.Common.Helpers
         }
 
 
-        public async Task<bool> DownloadIhoPubFile(string ihoPubFilePath, string batchId, string exchangeSetRootPath, string correlationId)
+        public async Task<bool> DownloadIhoPubFile(string ihoPubFilePath, string batchId, string aioExchangeSetPath, string correlationId)
         {
             string payloadJson = string.Empty;
             var accessToken = await authFssTokenProvider.GetManagedIdentityAuthAsync(fileShareServiceConfig.Value.ResourceId);
             string fileName = fileShareServiceConfig.Value.IhoPubFileName;
-            string filePath = Path.Combine(exchangeSetRootPath, fileName);
-            fileSystemHelper.CheckAndCreateFolder(exchangeSetRootPath);
+            string filePath = Path.Combine(aioExchangeSetPath, fileName);
+            fileSystemHelper.CheckAndCreateFolder(aioExchangeSetPath);
             string lineToWrite = string.Concat("File date: ", DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ssZ", CultureInfo.InvariantCulture));
             HttpResponseMessage httpIhoPubFileResponse;
             httpIhoPubFileResponse = await fileShareServiceClient.CallFileShareServiceApi(HttpMethod.Get, payloadJson, accessToken, ihoPubFilePath, CancellationToken.None, correlationId);

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/Helpers/IFileShareService.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/Helpers/IFileShareService.cs
@@ -22,7 +22,7 @@ namespace UKHO.ExchangeSetService.Common.Helpers
         Task<bool> CommitBatchToFss(string batchId, string correlationId, string exchangeSetZipPath, string fileName = "zip");
         Task<string> SearchIhoPubFilePath(string batchId, string correlationId);
         Task<string> SearchIhoCrtFilePath(string batchId, string correlationId);
-        Task<bool> DownloadIhoCrtFile(string ihoCrtFilePath, string batchId, string exchangeSetRootPath, string correlationId);
+        Task<bool> DownloadIhoCrtFile(string ihoCrtFilePath, string batchId, string aioExchangeSetPath, string correlationId);
         Task<bool> DownloadIhoPubFile(string ihoPubFilePath, string batchId, string exchangeSetRootPath, string correlationId);
     }
 }

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.FulfilmentService/Services/FulfilmentAncillaryFiles.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.FulfilmentService/Services/FulfilmentAncillaryFiles.cs
@@ -64,8 +64,6 @@ namespace UKHO.ExchangeSetService.FulfilmentService.Services
         {
             var catBuilder = new Catalog031BuilderFactory().Create();
             var readMeFileName = Path.Combine(exchangeSetRootPath, fileShareServiceConfig.Value.ReadMeFileName);
-            var ihoCrtFileName = Path.Combine(exchangeSetRootPath, fileShareServiceConfig.Value.IhoCrtFileName);
-            var ihoPubFileName = Path.Combine(exchangeSetRootPath, fileShareServiceConfig.Value.IhoPubFileName);
             var outputFileName = Path.Combine(exchangeSetRootPath, fileShareServiceConfig.Value.CatalogFileName);
 
             if (fileSystemHelper.CheckFileExists(readMeFileName))
@@ -76,25 +74,7 @@ namespace UKHO.ExchangeSetService.FulfilmentService.Services
                     Implementation = "TXT"
                 });
             }
-
-            if (fileSystemHelper.CheckFileExists(ihoCrtFileName))
-            {
-                catBuilder.Add(new CatalogEntry()
-                {
-                    FileLocation = fileShareServiceConfig.Value.IhoCrtFileName,
-                    Implementation = "CRT"
-                });
-            }
-
-            if (fileSystemHelper.CheckFileExists(ihoPubFileName))
-            {
-                catBuilder.Add(new CatalogEntry()
-                {
-                    FileLocation = fileShareServiceConfig.Value.IhoPubFileName,
-                    Implementation = "PUB"
-                });
-            }
-
+            
             if (listFulfilmentData != null && listFulfilmentData.Any())
             {
                 listFulfilmentData = listFulfilmentData.OrderBy(a => a.ProductName).ThenBy(b => b.EditionNumber).ThenBy(c => c.UpdateNumber).ToList();

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.FulfilmentService/Services/FulfilmentDataService.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.FulfilmentService/Services/FulfilmentDataService.cs
@@ -290,7 +290,7 @@ namespace UKHO.ExchangeSetService.FulfilmentService.Services
             return isDownloadReadMeFileSuccess;
         }
 
-        public async Task<bool> DownloadIhoCrtFile(string batchId, string exchangeSetRootPath, string correlationId)
+        public async Task<bool> DownloadIhoCrtFile(string batchId, string aioExchangeSetPath, string correlationId)
         {
             bool isDownloadIhoCrtFileSuccess = false;
             string ihoCrtFilePath = await logger.LogStartEndAndElapsedTimeAsync(EventIds.QueryFileShareServiceIhoCrtFileRequestStart,
@@ -310,7 +310,7 @@ namespace UKHO.ExchangeSetService.FulfilmentService.Services
                     "File share service download request for IHO.crt file for BatchId:{BatchId} and _X-Correlation-ID:{CorrelationId}",
                     async () =>
                     {
-                        return await fulfilmentFileShareService.DownloadIhoCrtFile(ihoCrtFilePath, batchId, exchangeSetRootPath, correlationId);
+                        return await fulfilmentFileShareService.DownloadIhoCrtFile(ihoCrtFilePath, batchId, aioExchangeSetPath, correlationId);
                     },
                     batchId, correlationId);
 
@@ -856,8 +856,8 @@ namespace UKHO.ExchangeSetService.FulfilmentService.Services
 
             return
             await DownloadReadMeFile(batchId, exchangeSetRootPath, correlationId) &&
-            await DownloadIhoCrtFile(batchId, exchangeSetRootPath, correlationId) &&
-            await DownloadIhoPubFile(batchId, exchangeSetRootPath, correlationId) &&
+            await DownloadIhoCrtFile(batchId, aioExchangeSetPath, correlationId) &&
+            await DownloadIhoPubFile(batchId, aioExchangeSetPath, correlationId) &&
             await CreateSerialAioFile(batchId, aioExchangeSetPath, correlationId, salesCatalogueDataResponse) &&
             await CreateProductFileForAio(batchId, exchangeSetInfoPath, correlationId, salesCatalogueDataResponse, scsRequestDateTime) &&
             await CreateCatalogFileForAio(batchId, exchangeSetRootPath, correlationId, listFulfilmentAioData, salesCatalogueDataResponse, salesCatalogueProductResponse);

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.FulfilmentService/Services/FulfilmentFileShareService.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.FulfilmentService/Services/FulfilmentFileShareService.cs
@@ -135,9 +135,9 @@ namespace UKHO.ExchangeSetService.FulfilmentService.Services
             return await fileShareService.DownloadIhoPubFile(filePath, batchId, exchangeSetRootPath, correlationId);
         }
 
-        public async Task<bool> DownloadIhoCrtFile(string filePath, string batchId, string exchangeSetRootPath, string correlationId)
+        public async Task<bool> DownloadIhoCrtFile(string filePath, string batchId, string aioExchangeSetPath, string correlationId)
         {
-            return await fileShareService.DownloadIhoCrtFile(filePath, batchId, exchangeSetRootPath, correlationId);
+            return await fileShareService.DownloadIhoCrtFile(filePath, batchId, aioExchangeSetPath, correlationId);
         }
 
         public async Task<bool> CreateZipFileForExchangeSet(string batchId, string exchangeSetZipRootPath, string correlationId)

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.FulfilmentService/Services/IFulfilmentFileShareService.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.FulfilmentService/Services/IFulfilmentFileShareService.cs
@@ -22,6 +22,6 @@ namespace UKHO.ExchangeSetService.FulfilmentService.Services
         Task<string> SearchIhoPubFilePath(string batchId, string correlationId);
         Task<string> SearchIhoCrtFilePath(string batchId, string correlationId);
         Task<bool> DownloadIhoPubFile(string filePath, string batchId, string exchangeSetRootPath, string correlationId);
-        Task<bool> DownloadIhoCrtFile(string filePath, string batchId, string exchangeSetRootPath, string correlationId);
+        Task<bool> DownloadIhoCrtFile(string filePath, string batchId, string aioExchangeSetPath, string correlationId);
     }
 }

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/Services/FulfilmentAncillaryFilesTest.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/Services/FulfilmentAncillaryFilesTest.cs
@@ -56,8 +56,6 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
                 EncRoot = "ENC_ROOT",
                 ExchangeSetFileFolder = "V01X01",
                 ReadMeFileName = "ReadMe.txt",
-                IhoCrtFileName = "IHO.crt",
-                IhoPubFileName = "IHO.pub",
                 CatalogFileName = "CATALOG.031",
                 SerialFileName = "TEST.ENC",
                 SerialAioFileName = "TEST.AIO",


### PR DESCRIPTION
Standardize parameter name to aioExchangeSetPath across methods. Update method signatures and internal logic in FileShareService, IFileShareService, FulfilmentDataService, and FulfilmentFileShareService. Remove IhoCrtFileName and IhoPubFileName checks from catalog creation logic in FulfilmentAncillaryFiles. Adjust related tests accordingly.