### PR TITLE
Disable XML transformation in FileTransform@2 tasks

### DIFF
--- a/Deployment/templates/Deploy.yml
+++ b/Deployment/templates/Deploy.yml
@@ -139,7 +139,7 @@ jobs:
             displayName: "File Transform: functionaltests"
             inputs:
               folderPath: '$(Build.SourcesDirectory)/functionaltests/'
-              xmlTransformationRules:
+              enableXmlTransform: false
               jsonTargetFiles: '**/appsettings.json'
 
           - task: UseDotNet@2

--- a/Deployment/templates/continuous-deployment-v2.yml
+++ b/Deployment/templates/continuous-deployment-v2.yml
@@ -10,7 +10,7 @@ steps:
     displayName: "File Transform: Ess Config" #Replace exchange set instance value from pipeline 
     inputs:
       folderPath: '$(Pipeline.Workspace)/terraformartifact/src'
-      xmlTransformationRules:
+      enableXmlTransform: false
       jsonTargetFiles: '**/appsettings.json'
 
   - task: PowerShell@2
@@ -39,7 +39,7 @@ steps:
     displayName: "File Transform: WebJob"
     inputs:
       folderPath: '$(Pipeline.Workspace)/ExchangeSetService/*.zip'
-      xmlTransformationRules:
+      enableXmlTransform: false
       jsonTargetFiles: '**/appsettings.json'
 
   - task: AzureCLI@2
@@ -56,7 +56,7 @@ steps:
     displayName: "File Transform: WebAppSettings"
     inputs:
       folderPath: '$(Pipeline.Workspace)/ExchangeSetServiceWebAPI/*.zip'
-      xmlTransformationRules:
+      enableXmlTransform: false
       jsonTargetFiles: '**/appsettings.json'
 
   - task: AzureWebApp@1

--- a/Deployment/templates/continuous-deployment.yml
+++ b/Deployment/templates/continuous-deployment.yml
@@ -10,7 +10,7 @@ steps:
     displayName: "File Transform: Ess Config" #Replace exchange set instance value from pipeline 
     inputs:
       folderPath: '$(Pipeline.Workspace)/terraformartifact/src'
-      xmlTransformationRules:
+      enableXmlTransform: false
       jsonTargetFiles: '**/appsettings.json'
 
   - task: PowerShell@2
@@ -39,7 +39,7 @@ steps:
     displayName: "File Transform: WebJob"
     inputs:
       folderPath: '$(Pipeline.Workspace)/ExchangeSetService/*.zip'
-      xmlTransformationRules:
+      enableXmlTransform: false
       jsonTargetFiles: '**/appsettings.json'
 
   - task: AzureCLI@2
@@ -56,7 +56,7 @@ steps:
     displayName: "File Transform: WebAppSettings"
     inputs:
       folderPath: '$(Pipeline.Workspace)/ExchangeSetServiceWebAPI/*.zip'
-      xmlTransformationRules:
+      enableXmlTransform: false
       jsonTargetFiles: '**/appsettings.json'
 
   - task: AzureWebApp@1

--- a/MockApiDeployment/templates/mock-api-continuous-deployment.yml
+++ b/MockApiDeployment/templates/mock-api-continuous-deployment.yml
@@ -19,14 +19,14 @@ steps:
     displayName: "File Transform: WebAppSettings"
     inputs:
       folderPath: '$(Pipeline.Workspace)/ExchangeSetServiceWebAPI/*.zip'
-      xmlTransformationRules:
+      enableXmlTransform: false
       jsonTargetFiles: '**/appsettings.json'
 
   - task: FileTransform@2
     displayName: "File Transform: WebJob"
     inputs:
       folderPath: '$(Pipeline.Workspace)/ExchangeSetService/*.zip'
-      xmlTransformationRules:
+      enableXmlTransform: false
       jsonTargetFiles: '**/appsettings.json'
 
   - task: AzureCLI@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -505,7 +505,7 @@ stages:
                   displayName: "File Transform: functionaltests"
                   inputs:
                     folderPath: '$(Build.SourcesDirectory)/functionaltests/'
-                    xmlTransformationRules:
+                    enableXmlTransform: false
                     jsonTargetFiles: '**/appsettings.json'
 
                 - task: UseDotNet@2
@@ -672,7 +672,7 @@ stages:
                   displayName: "File Transform: functionaltests"
                   inputs:
                     folderPath: '$(Build.SourcesDirectory)/functionaltests/'
-                    xmlTransformationRules:
+                    enableXmlTransform: false
                     jsonTargetFiles: '**/appsettings.json'
 
                 - task: UseDotNet@2
@@ -811,7 +811,7 @@ stages:
                   displayName: "File Transform: functionaltests"
                   inputs:
                     folderPath: '$(Build.SourcesDirectory)/functionaltests/'
-                    xmlTransformationRules:
+                    enableXmlTransform: false
                     jsonTargetFiles: '**/appsettings.json'
 
                 - task: UseDotNet@2
@@ -1051,7 +1051,7 @@ stages:
                   displayName: "File Transform: functionaltests"
                   inputs:
                     folderPath: '$(Build.SourcesDirectory)/functionaltests/'
-                    xmlTransformationRules:
+                    enableXmlTransform: false
                     jsonTargetFiles: '**/appsettings.json'
 
                 - task: UseDotNet@2
@@ -1142,7 +1142,7 @@ stages:
                   displayName: "File Transform: functionaltests"
                   inputs:
                     folderPath: '$(Build.SourcesDirectory)/functionaltests/'
-                    xmlTransformationRules:
+                    enableXmlTransform: false
                     jsonTargetFiles: '**/appsettings.json'
 
                 - task: UseDotNet@2


### PR DESCRIPTION
Replaced `xmlTransformationRules` with `enableXmlTransform` set to `false` in the `FileTransform@2` task. This change disables XML transformations by default.