### PR TITLE
Lock AioEnabled Flag to true

### DIFF
--- a/Deployment/templates/Deploy.yml
+++ b/Deployment/templates/Deploy.yml
@@ -143,13 +143,6 @@ jobs:
               xmlTransformationRules: ''
               jsonTargetFiles: '**/appsettings.json'
 
-          # - task: UseDotNet@2
-          #   displayName: 'Use .NET SDK'
-          #   inputs:
-          #     packageType: sdk
-          #     useGlobalJson: true
-          #     workingDirectory: '$(Build.SourcesDirectory)'
-
           - task: AzureCLI@2
             displayName: "Swap ESS API and ESS FulfilmentService Configuration AIOEnabled"
             condition: always()

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Services/ProductDataServiceTests.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Services/ProductDataServiceTests.cs
@@ -691,7 +691,6 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
             A.CallTo(() => fakeProductIdentifierValidator.Validate(A<ProductIdentifierRequest>.Ignored))
                 .Returns(new ValidationResult(new List<ValidationFailure>()));
             string[] productIdentifiers = new string[] { "GB123456", "GB160060", "AU334550", "US2ARCGD" };
-            //// rhz fakeAioConfiguration.Value.IsAioEnabled = true;
             fakeAioConfiguration.Value.AioCells = "US2ARCGD";
             string callbackUri = string.Empty;
             var salesCatalogueResponse = GetSalesCatalogueResponse();
@@ -1319,7 +1318,6 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                 FileSize = 400
             });
             var azureAdToken = GetAzureADToken();
-            //// rhz fakeAioConfiguration.Value.IsAioEnabled = true;
             fakeAioConfiguration.Value.AioCells = "US2ARCGD";
             salesCatalogueResponse.ResponseCode = HttpStatusCode.OK;
             A.CallTo(() => fakeSalesCatalogueService.PostProductVersionsAsync(A<List<ProductVersionRequest>>.Ignored, A<string>.Ignored))
@@ -1729,7 +1727,6 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
         {
             A.CallTo(() => fakeProductDataSinceDateTimeValidator.Validate(A<ProductDataSinceDateTimeRequest>.Ignored))
                 .Returns(new ValidationResult(new List<ValidationFailure>()));
-            //// rhz fakeAioConfiguration.Value.IsAioEnabled = true;
             fakeAioConfiguration.Value.AioCells = "US2ARCGD";
             var salesCatalogueResponse = GetSalesCatalogueResponse();
             salesCatalogueResponse.ResponseCode = HttpStatusCode.OK;

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Services/ProductDataServiceTests.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Services/ProductDataServiceTests.cs
@@ -505,22 +505,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                     ExchangeSetStandard = exchangeSetStandard.ToString()
                 }, azureAdToken);
 
-            var exchangeSetResponseAioToggleOff = GetExchangeSetResponseAioToggleOff();
-
             Assert.That(HttpStatusCode.Created, Is.EqualTo(result.HttpStatusCode));
-            Assert.That(exchangeSetResponseAioToggleOff.ExchangeSetCellCount, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetCellCount));
-            Assert.That(exchangeSetResponseAioToggleOff.RequestedProductCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductCount));
-            Assert.That(exchangeSetResponseAioToggleOff.RequestedProductsAlreadyUpToDateCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductsAlreadyUpToDateCount));
-            Assert.That(exchangeSetResponseAioToggleOff.Links.ExchangeSetBatchStatusUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetBatchStatusUri.Href));
-            Assert.That(exchangeSetResponseAioToggleOff.Links.ExchangeSetBatchDetailsUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetBatchDetailsUri.Href));
-            Assert.That(exchangeSetResponseAioToggleOff.Links.ExchangeSetFileUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetFileUri.Href));
-            Assert.That(exchangeSetResponseAioToggleOff.ExchangeSetUrlExpiryDateTime, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetUrlExpiryDateTime));
-            Assert.That(exchangeSetResponseAioToggleOff.BatchId, Is.EqualTo(result.BatchId));
-
-            A.CallTo(logger).Where(call => call.Method.Name == "Log"
-            && call.GetArgument<LogLevel>(0) == LogLevel.Information
-            && call.GetArgument<EventId>(1) == EventIds.AIOToggleIsOff.ToEventId()
-            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "AIO toggle is Off, additional aio cell details for AioCells:{AioCells} | BatchId:{BatchId} | _X-Correlation-ID : {CorrelationId}").MustHaveHappenedOnceExactly();
 
             A.CallTo(logger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -564,20 +549,10 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                     CallbackUri = callbackUri
                 }, azureB2CToken); // AzureB2C Token but file size is less than 300 Mb
 
-            var exchangeSetResponseAioToggleOff = GetExchangeSetResponseAioToggleOff();
 
             Assert.That(HttpStatusCode.Created, Is.EqualTo(result.HttpStatusCode));
             Assert.That(result.LastModified, Is.Not.Null);
-            Assert.That(exchangeSetResponseAioToggleOff.ExchangeSetCellCount, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetCellCount));
-            Assert.That(exchangeSetResponseAioToggleOff.RequestedProductCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductCount));
-            Assert.That(exchangeSetResponseAioToggleOff.RequestedProductsAlreadyUpToDateCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductsAlreadyUpToDateCount));
-            Assert.That(exchangeSetResponseAioToggleOff.BatchId, Is.EqualTo(result.BatchId));
-
-            A.CallTo(logger).Where(call => call.Method.Name == "Log"
-            && call.GetArgument<LogLevel>(0) == LogLevel.Information
-            && call.GetArgument<EventId>(1) == EventIds.AIOToggleIsOff.ToEventId()
-            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "AIO toggle is Off, additional aio cell details for AioCells:{AioCells} | BatchId:{BatchId} | _X-Correlation-ID : {CorrelationId}").MustHaveHappenedOnceExactly();
-
+            
             A.CallTo(logger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
             && call.GetArgument<EventId>(1) == EventIds.FSSCreateBatchRequestStart.ToEventId()
@@ -695,10 +670,6 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                     ExchangeSetStandard = ExchangeSetStandard.s63.ToString()
                 }, azureAdToken);
 
-            A.CallTo(logger).Where(call => call.Method.Name == "Log"
-            && call.GetArgument<LogLevel>(0) == LogLevel.Information
-            && call.GetArgument<EventId>(1) == EventIds.AIOToggleIsOff.ToEventId()
-            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "AIO toggle is Off, additional aio cell details for AioCells:{AioCells} | BatchId:{BatchId} | _X-Correlation-ID : {CorrelationId}").MustHaveHappenedOnceExactly();
 
             A.CallTo(logger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -713,82 +684,14 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
             A.CallTo(() => fakeExchangeSetStorageProvider.SaveSalesCatalogueStorageDetails(salesCatalogueResponse.ResponseBody, CreateBatchResponseModel.ResponseBody.BatchId, callBackUri, A<string>.Ignored, correlationId, A<string>.Ignored, salesCatalogueResponse.ScsRequestDateTime, A<bool>.Ignored, A<bool>.Ignored, A<ExchangeSetResponse>.Ignored)).MustNotHaveHappened();
         }
 
-        [Test]
-        public async Task WhenValidProductIdentifierRequest_And_AIOToggleIsOff_ThenCreateProductDataByProductIdentifierReturnsOkrequest()
-        {
-            A.CallTo(() => fakeProductIdentifierValidator.Validate(A<ProductIdentifierRequest>.Ignored))
-                .Returns(new ValidationResult(new List<ValidationFailure>()));
-            string[] productIdentifiers = new string[] { "GB123456", "GB160060", "AU334550", "US2ARCGD" };
-            fakeAioConfiguration.Value.IsAioEnabled = false;
-            fakeAioConfiguration.Value.AioCells = "US2ARCGD";
-            string callbackUri = string.Empty;
-            var salesCatalogueResponse = GetSalesCatalogueResponse();
-            var azureAdToken = GetAzureADToken();
-
-            salesCatalogueResponse.ResponseCode = HttpStatusCode.OK;
-            A.CallTo(() => fakeSalesCatalogueService.PostProductIdentifiersAsync(A<List<string>>.Ignored, A<string>.Ignored))
-                .Returns(salesCatalogueResponse);
-            A.CallTo(() => fakeAzureAdB2CHelper.IsAzureB2CUser(A<AzureAdB2C>.Ignored, A<string>.Ignored)).Returns(false);
-
-            var exchangeSetResponse = GetExchangeSetResponse();
-            A.CallTo(() => fakeMapper.Map<ExchangeSetResponse>(A<ProductCounts>.Ignored)).Returns(exchangeSetResponse);
-            A.CallTo(() => fakeMapper.Map<IEnumerable<RequestedProductsNotInExchangeSet>>(A<List<RequestedProductsNotReturned>>.Ignored))
-                .Returns(exchangeSetResponse.RequestedProductsNotInExchangeSet);
-
-            var CreateBatchResponseModel = CreateBatchResponse();
-            CreateBatchResponseModel.ResponseCode = HttpStatusCode.Created;
-            string callBackUri = "https://exchange-set-service.com/myCallback?secret=sharedSecret&po=1234";
-            string correlationId = "a6670458-9bbc-4b52-95a2-d1f50fe9e3ae";
-
-            A.CallTo(() => fakeFileShareService.CreateBatch(A<string>.Ignored, A<string>.Ignored)).Returns(CreateBatchResponseModel);
-            A.CallTo(() => fakeExchangeSetStorageProvider.SaveSalesCatalogueStorageDetails(salesCatalogueResponse.ResponseBody, CreateBatchResponseModel.ResponseBody.BatchId, callBackUri, A<string>.Ignored, correlationId, A<string>.Ignored, salesCatalogueResponse.ScsRequestDateTime, A<bool>.Ignored, A<bool>.Ignored, A<ExchangeSetResponse>.Ignored)).Returns(true);
-
-            var result = await service.CreateProductDataByProductIdentifiers(
-                new ProductIdentifierRequest()
-                {
-                    ProductIdentifier = productIdentifiers,
-                    CallbackUri = callbackUri,
-                    ExchangeSetStandard = ExchangeSetStandard.s63.ToString()
-                }, azureAdToken);
-
-            var exchangeSetResponseAioToggleOff = GetExchangeSetResponseAioToggleOff();
-            exchangeSetResponseAioToggleOff.RequestedProductCount += 1; //one aio cell passed
-
-            Assert.That(HttpStatusCode.Created, Is.EqualTo(result.HttpStatusCode));
-            Assert.That(exchangeSetResponseAioToggleOff.ExchangeSetCellCount, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetCellCount));
-            Assert.That(exchangeSetResponseAioToggleOff.RequestedProductCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductCount));
-            Assert.That(exchangeSetResponseAioToggleOff.RequestedProductsAlreadyUpToDateCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductsAlreadyUpToDateCount));
-            Assert.That(exchangeSetResponseAioToggleOff.Links.ExchangeSetBatchStatusUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetBatchStatusUri.Href));
-            Assert.That(exchangeSetResponseAioToggleOff.Links.ExchangeSetBatchDetailsUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetBatchDetailsUri.Href));
-            Assert.That(exchangeSetResponseAioToggleOff.Links.ExchangeSetFileUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetFileUri.Href));
-            Assert.That(exchangeSetResponseAioToggleOff.ExchangeSetUrlExpiryDateTime, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetUrlExpiryDateTime));
-            Assert.That(exchangeSetResponseAioToggleOff.BatchId, Is.EqualTo(result.BatchId));
-            //Aio cell details
-            Assert.That(exchangeSetResponseAioToggleOff.RequestedProductsNotInExchangeSet.Count, Is.EqualTo(result.ExchangeSetResponse.RequestedProductsNotInExchangeSet.Count));
-
-            A.CallTo(logger).Where(call => call.Method.Name == "Log"
-            && call.GetArgument<LogLevel>(0) == LogLevel.Information
-            && call.GetArgument<EventId>(1) == EventIds.AIOToggleIsOff.ToEventId()
-            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "AIO toggle is Off, additional aio cell details for AioCells:{AioCells} | BatchId:{BatchId} | _X-Correlation-ID : {CorrelationId}").MustHaveHappenedOnceExactly();
-
-            A.CallTo(logger).Where(call => call.Method.Name == "Log"
-            && call.GetArgument<LogLevel>(0) == LogLevel.Information
-            && call.GetArgument<EventId>(1) == EventIds.FSSCreateBatchRequestStart.ToEventId()
-            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "FSS create batch endpoint request for _X-Correlation-ID:{CorrelationId}").MustHaveHappenedOnceExactly();
-
-            A.CallTo(logger).Where(call => call.Method.Name == "Log"
-            && call.GetArgument<LogLevel>(0) == LogLevel.Information
-            && call.GetArgument<EventId>(1) == EventIds.SCSResponseStoreRequestStart.ToEventId()
-            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "SCS response store request for BatchId:{batchId} and _X-Correlation-ID:{CorrelationId}").MustHaveHappenedOnceExactly();
-        }
-
+        
         [Test]
         public async Task WhenValidProductIdentifierRequest_And_AIOToggleIsOn_ThenCreateProductDataByProductIdentifierReturnsOkrequest()
         {
             A.CallTo(() => fakeProductIdentifierValidator.Validate(A<ProductIdentifierRequest>.Ignored))
                 .Returns(new ValidationResult(new List<ValidationFailure>()));
             string[] productIdentifiers = new string[] { "GB123456", "GB160060", "AU334550", "US2ARCGD" };
-            fakeAioConfiguration.Value.IsAioEnabled = true;
+            //// rhz fakeAioConfiguration.Value.IsAioEnabled = true;
             fakeAioConfiguration.Value.AioCells = "US2ARCGD";
             string callbackUri = string.Empty;
             var salesCatalogueResponse = GetSalesCatalogueResponse();
@@ -922,23 +825,9 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                     ExchangeSetStandard = ExchangeSetStandard.s63.ToString()
                 }, GetAzureADToken());
 
-            var exchangeSetResponseAioToggleOff = GetExchangeSetResponseAioToggleOff();
 
             result.Should().BeOfType<ExchangeSetServiceResponse>();
             result.HttpStatusCode.Should().Be(HttpStatusCode.Created);
-            result.ExchangeSetResponse.ExchangeSetCellCount.Should().Be(exchangeSetResponseAioToggleOff.ExchangeSetCellCount);
-            result.ExchangeSetResponse.RequestedProductCount.Should().Be(exchangeSetResponseAioToggleOff.RequestedProductCount);
-            result.ExchangeSetResponse.RequestedProductsAlreadyUpToDateCount.Should().Be(exchangeSetResponseAioToggleOff.RequestedProductsAlreadyUpToDateCount);
-            result.ExchangeSetResponse.Links.ExchangeSetBatchStatusUri.Href.Should().Be(exchangeSetResponseAioToggleOff.Links.ExchangeSetBatchStatusUri.Href);
-            result.ExchangeSetResponse.Links.ExchangeSetBatchDetailsUri.Href.Should().Be(exchangeSetResponseAioToggleOff.Links.ExchangeSetBatchDetailsUri.Href);
-            result.ExchangeSetResponse.Links.ExchangeSetFileUri.Href.Should().Be(exchangeSetResponseAioToggleOff.Links.ExchangeSetFileUri.Href);
-            result.ExchangeSetResponse.ExchangeSetUrlExpiryDateTime.Should().Be(exchangeSetResponseAioToggleOff.ExchangeSetUrlExpiryDateTime);
-            result.BatchId.Should().Be(exchangeSetResponseAioToggleOff.BatchId);
-
-            A.CallTo(logger).Where(call => call.Method.Name == "Log"
-            && call.GetArgument<LogLevel>(0) == LogLevel.Information
-            && call.GetArgument<EventId>(1) == EventIds.AIOToggleIsOff.ToEventId()
-            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "AIO toggle is Off, additional aio cell details for AioCells:{AioCells} | BatchId:{BatchId} | _X-Correlation-ID : {CorrelationId}").MustHaveHappenedOnceExactly();
 
             A.CallTo(logger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -1079,13 +968,8 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                 ExchangeSetStandard = exchangeSetStandard.ToString()
             }, azureAdToken);
 
-            var exchangeSetResponseAioToggleOff = GetExchangeSetResponseAioToggleOff();
 
             Assert.That(HttpStatusCode.Created, Is.EqualTo(result.HttpStatusCode));
-            Assert.That(exchangeSetResponseAioToggleOff.ExchangeSetCellCount, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetCellCount));
-            Assert.That(exchangeSetResponseAioToggleOff.RequestedProductCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductCount));
-            Assert.That(exchangeSetResponseAioToggleOff.RequestedProductsAlreadyUpToDateCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductsAlreadyUpToDateCount));
-            Assert.That(exchangeSetResponseAioToggleOff.BatchId, Is.EqualTo(result.BatchId));
 
             A.CallTo(logger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -1097,10 +981,6 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
             && call.GetArgument<EventId>(1) == EventIds.FSSCreateBatchRequestStart.ToEventId()
             && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "FSS create batch endpoint request for _X-Correlation-ID:{CorrelationId}").MustHaveHappenedOnceExactly();
 
-            A.CallTo(logger).Where(call => call.Method.Name == "Log"
-            && call.GetArgument<LogLevel>(0) == LogLevel.Information
-            && call.GetArgument<EventId>(1) == EventIds.AIOToggleIsOff.ToEventId()
-            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "AIO toggle is Off, additional aio cell details for AioCells:{AioCells} | BatchId:{BatchId} | _X-Correlation-ID : {CorrelationId}").MustHaveHappenedOnceExactly();
         }
 
         [Test]
@@ -1340,86 +1220,9 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
             && call.GetArgument<EventId>(1) == EventIds.FSSCreateBatchRequestStart.ToEventId()
             && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "FSS create batch endpoint request for _X-Correlation-ID:{CorrelationId}").MustHaveHappenedOnceExactly();
 
-            A.CallTo(logger).Where(call => call.Method.Name == "Log"
-            && call.GetArgument<LogLevel>(0) == LogLevel.Information
-            && call.GetArgument<EventId>(1) == EventIds.AIOToggleIsOff.ToEventId()
-            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "AIO toggle is Off, additional aio cell details for AioCells:{AioCells} | BatchId:{BatchId} | _X-Correlation-ID : {CorrelationId}").MustHaveHappenedOnceExactly();
         }
 
-        [Test]
-        public async Task WhenValidProductVersionRequest_And_AIOToggleIsOff_ThenCreateProductDataByProductVersionsReturnsOkrequest()
-        {
-            A.CallTo(() => fakeProductVersionValidator.Validate(A<ProductDataProductVersionsRequest>.Ignored))
-                .Returns(new ValidationResult(new List<ValidationFailure>()));
-            var salesCatalogueResponse = GetSalesCatalogueResponse();
-            var azureAdToken = GetAzureADToken();
-            fakeAioConfiguration.Value.IsAioEnabled = false;
-            fakeAioConfiguration.Value.AioCells = "US2ARCGD";
-            salesCatalogueResponse.ResponseCode = HttpStatusCode.OK;
-            A.CallTo(() => fakeSalesCatalogueService.PostProductVersionsAsync(A<List<ProductVersionRequest>>.Ignored, A<string>.Ignored))
-                .Returns(salesCatalogueResponse);
-
-            var exchangeSetResponse = GetExchangeSetResponse();
-            A.CallTo(() => fakeMapper.Map<ExchangeSetResponse>(A<ProductCounts>.Ignored)).Returns(exchangeSetResponse);
-            A.CallTo(() => fakeMapper.Map<IEnumerable<RequestedProductsNotInExchangeSet>>(A<List<RequestedProductsNotReturned>>.Ignored))
-                .Returns(exchangeSetResponse.RequestedProductsNotInExchangeSet);
-            A.CallTo(() => fakeAzureAdB2CHelper.IsAzureB2CUser(A<AzureAdB2C>.Ignored, A<string>.Ignored)).Returns(false);
-
-            var CreateBatchResponseModel = CreateBatchResponse();
-            CreateBatchResponseModel.ResponseCode = HttpStatusCode.Created;
-
-            A.CallTo(() => fakeFileShareService.CreateBatch(A<string>.Ignored, A<string>.Ignored)).Returns(CreateBatchResponseModel);
-
-            var result = await service.CreateProductDataByProductVersions(new ProductDataProductVersionsRequest()
-            {
-                ProductVersions = new List<ProductVersionRequest>() {
-                    new ProductVersionRequest {
-                            ProductName = "GB123456", EditionNumber = 6, UpdateNumber = 3
-                    },new ProductVersionRequest {
-                            ProductName = "GB160060", EditionNumber = 2, UpdateNumber = 4
-                    },new ProductVersionRequest {
-                            ProductName = "AU334550", EditionNumber = 8, UpdateNumber = 1
-                    },
-                    new ProductVersionRequest {
-                            ProductName = "US2ARCGD", EditionNumber = 4, UpdateNumber = 6
-                    }
-                },
-                CallbackUri = "",
-                ExchangeSetStandard = ExchangeSetStandard.s63.ToString()
-            }, azureAdToken);
-
-            var exchangeSetResponseAioToggleOff = GetExchangeSetResponseAioToggleOff();
-            exchangeSetResponseAioToggleOff.RequestedProductCount += 1; //one aio cell passed
-
-            Assert.That(result, Is.InstanceOf<ExchangeSetServiceResponse>());
-            Assert.That(HttpStatusCode.Created, Is.EqualTo(result.HttpStatusCode));
-            Assert.That(exchangeSetResponseAioToggleOff.ExchangeSetCellCount, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetCellCount));
-            Assert.That(exchangeSetResponseAioToggleOff.RequestedProductCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductCount));
-            Assert.That(exchangeSetResponseAioToggleOff.RequestedProductsAlreadyUpToDateCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductsAlreadyUpToDateCount));
-            Assert.That(exchangeSetResponseAioToggleOff.Links.ExchangeSetBatchStatusUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetBatchStatusUri.Href));
-            Assert.That(exchangeSetResponseAioToggleOff.Links.ExchangeSetBatchDetailsUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetBatchDetailsUri.Href));
-            Assert.That(exchangeSetResponseAioToggleOff.Links.ExchangeSetFileUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetFileUri.Href));
-            Assert.That(exchangeSetResponseAioToggleOff.ExchangeSetUrlExpiryDateTime, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetUrlExpiryDateTime));
-            Assert.That(exchangeSetResponseAioToggleOff.BatchId, Is.EqualTo(result.BatchId));
-            //Aio cell details
-            Assert.That(exchangeSetResponseAioToggleOff.RequestedProductsNotInExchangeSet.Count, Is.EqualTo(result.ExchangeSetResponse.RequestedProductsNotInExchangeSet.Count));
-
-            A.CallTo(logger).Where(call => call.Method.Name == "Log"
-            && call.GetArgument<LogLevel>(0) == LogLevel.Information
-            && call.GetArgument<EventId>(1) == EventIds.SCSResponseStoreRequestStart.ToEventId()
-            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "SCS response store request for BatchId:{batchId} and _X-Correlation-ID:{CorrelationId}").MustHaveHappenedOnceExactly();
-
-            A.CallTo(logger).Where(call => call.Method.Name == "Log"
-            && call.GetArgument<LogLevel>(0) == LogLevel.Information
-            && call.GetArgument<EventId>(1) == EventIds.FSSCreateBatchRequestStart.ToEventId()
-            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "FSS create batch endpoint request for _X-Correlation-ID:{CorrelationId}").MustHaveHappenedOnceExactly();
-
-            A.CallTo(logger).Where(call => call.Method.Name == "Log"
-            && call.GetArgument<LogLevel>(0) == LogLevel.Information
-            && call.GetArgument<EventId>(1) == EventIds.AIOToggleIsOff.ToEventId()
-            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "AIO toggle is Off, additional aio cell details for AioCells:{AioCells} | BatchId:{BatchId} | _X-Correlation-ID : {CorrelationId}").MustHaveHappenedOnceExactly();
-        }
-
+        
         [Test]
         public async Task WhenValidProductVersionRequestWithExchangeSetStandardS57_AndFileSizeIsMoreThan700Mb_ThenCreateProductDataByProductVersionsReturnsBadRequest()
         {
@@ -1481,23 +1284,10 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                 ExchangeSetStandard = ExchangeSetStandard.s63.ToString()
             }, GetAzureADToken());
 
-            var exchangeSetResponseAioToggleOff = GetExchangeSetResponseAioToggleOff();
 
             result.Should().BeOfType<ExchangeSetServiceResponse>();
             result.HttpStatusCode.Should().Be(HttpStatusCode.Created);
-            result.ExchangeSetResponse.ExchangeSetCellCount.Should().Be(exchangeSetResponseAioToggleOff.ExchangeSetCellCount);
-            result.ExchangeSetResponse.RequestedProductCount.Should().Be(exchangeSetResponseAioToggleOff.RequestedProductCount);
-            result.ExchangeSetResponse.RequestedProductsAlreadyUpToDateCount.Should().Be(exchangeSetResponseAioToggleOff.RequestedProductsAlreadyUpToDateCount);
-            result.ExchangeSetResponse.Links.ExchangeSetBatchStatusUri.Href.Should().Be(exchangeSetResponseAioToggleOff.Links.ExchangeSetBatchStatusUri.Href);
-            result.ExchangeSetResponse.Links.ExchangeSetBatchDetailsUri.Href.Should().Be(exchangeSetResponseAioToggleOff.Links.ExchangeSetBatchDetailsUri.Href);
-            result.ExchangeSetResponse.Links.ExchangeSetFileUri.Href.Should().Be(exchangeSetResponseAioToggleOff.Links.ExchangeSetFileUri.Href);
-            result.ExchangeSetResponse.ExchangeSetUrlExpiryDateTime.Should().Be(exchangeSetResponseAioToggleOff.ExchangeSetUrlExpiryDateTime);
-            result.BatchId.Should().Be(exchangeSetResponseAioToggleOff.BatchId);
 
-            A.CallTo(logger).Where(call => call.Method.Name == "Log"
-            && call.GetArgument<LogLevel>(0) == LogLevel.Information
-            && call.GetArgument<EventId>(1) == EventIds.AIOToggleIsOff.ToEventId()
-            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "AIO toggle is Off, additional aio cell details for AioCells:{AioCells} | BatchId:{BatchId} | _X-Correlation-ID : {CorrelationId}").MustHaveHappenedOnceExactly();
 
             A.CallTo(logger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -1529,7 +1319,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                 FileSize = 400
             });
             var azureAdToken = GetAzureADToken();
-            fakeAioConfiguration.Value.IsAioEnabled = true;
+            //// rhz fakeAioConfiguration.Value.IsAioEnabled = true;
             fakeAioConfiguration.Value.AioCells = "US2ARCGD";
             salesCatalogueResponse.ResponseCode = HttpStatusCode.OK;
             A.CallTo(() => fakeSalesCatalogueService.PostProductVersionsAsync(A<List<ProductVersionRequest>>.Ignored, A<string>.Ignored))
@@ -1757,23 +1547,10 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                 CallbackUri = string.Empty
             }, GetAzureADToken());
 
-            var exchangeSetResponseAioToggleOff = GetExchangeSetResponseAioToggleOff();
 
             result.Should().BeOfType<ExchangeSetServiceResponse>();
             result.HttpStatusCode.Should().Be(HttpStatusCode.Created);
-            result.ExchangeSetResponse.ExchangeSetCellCount.Should().Be(exchangeSetResponseAioToggleOff.ExchangeSetCellCount);
-            result.ExchangeSetResponse.RequestedProductCount.Should().Be(exchangeSetResponseAioToggleOff.RequestedProductCount);
-            result.ExchangeSetResponse.RequestedProductsAlreadyUpToDateCount.Should().Be(exchangeSetResponseAioToggleOff.RequestedProductsAlreadyUpToDateCount);
-            result.ExchangeSetResponse.Links.ExchangeSetBatchStatusUri.Href.Should().Be(exchangeSetResponseAioToggleOff.Links.ExchangeSetBatchStatusUri.Href);
-            result.ExchangeSetResponse.Links.ExchangeSetBatchDetailsUri.Href.Should().Be(exchangeSetResponseAioToggleOff.Links.ExchangeSetBatchDetailsUri.Href);
-            result.ExchangeSetResponse.Links.ExchangeSetFileUri.Href.Should().Be(exchangeSetResponseAioToggleOff.Links.ExchangeSetFileUri.Href);
-            result.ExchangeSetResponse.ExchangeSetUrlExpiryDateTime.Should().Be(exchangeSetResponseAioToggleOff.ExchangeSetUrlExpiryDateTime);
-            result.BatchId.Should().Be(exchangeSetResponseAioToggleOff.BatchId);
-
-            A.CallTo(logger).Where(call => call.Method.Name == "Log"
-            && call.GetArgument<LogLevel>(0) == LogLevel.Information
-            && call.GetArgument<EventId>(1) == EventIds.AIOToggleIsOff.ToEventId()
-            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "AIO toggle is Off, additional aio cell details for AioCells:{AioCells} | BatchId:{BatchId} | _X-Correlation-ID : {CorrelationId}").MustHaveHappenedOnceExactly();
+            
 
             A.CallTo(logger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -1869,18 +1646,10 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
 
             var result = await service.CreateProductDataSinceDateTime(new ProductDataSinceDateTimeRequest(), GetAzureB2CToken());//B2C token passed and file size less than 300 mb
 
-            var exchangeSetResponseAioToggleOff = GetExchangeSetResponseAioToggleOff();
 
             Assert.That(result, Is.InstanceOf<ExchangeSetServiceResponse>());
             Assert.That(HttpStatusCode.Created, Is.EqualTo(result.HttpStatusCode));
-            Assert.That(exchangeSetResponseAioToggleOff.ExchangeSetCellCount, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetCellCount));
-            Assert.That(exchangeSetResponseAioToggleOff.RequestedProductCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductCount));
-            Assert.That(exchangeSetResponseAioToggleOff.RequestedProductsAlreadyUpToDateCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductsAlreadyUpToDateCount));
-            Assert.That(exchangeSetResponseAioToggleOff.Links.ExchangeSetBatchStatusUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetBatchStatusUri.Href));
-            Assert.That(exchangeSetResponseAioToggleOff.Links.ExchangeSetBatchDetailsUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetBatchDetailsUri.Href));
-            Assert.That(exchangeSetResponseAioToggleOff.Links.ExchangeSetFileUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetFileUri.Href));
-            Assert.That(exchangeSetResponseAioToggleOff.ExchangeSetUrlExpiryDateTime, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetUrlExpiryDateTime));
-            Assert.That(exchangeSetResponseAioToggleOff.BatchId, Is.EqualTo(result.BatchId));
+            
 
             A.CallTo(logger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -1892,10 +1661,6 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
             && call.GetArgument<EventId>(1) == EventIds.FSSCreateBatchRequestStart.ToEventId()
             && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "FSS create batch endpoint request for _X-Correlation-ID:{CorrelationId}").MustHaveHappenedOnceExactly();
 
-            A.CallTo(logger).Where(call => call.Method.Name == "Log"
-            && call.GetArgument<LogLevel>(0) == LogLevel.Information
-            && call.GetArgument<EventId>(1) == EventIds.AIOToggleIsOff.ToEventId()
-            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "AIO toggle is Off, additional aio cell details for AioCells:{AioCells} | BatchId:{BatchId} | _X-Correlation-ID : {CorrelationId}").MustHaveHappenedOnceExactly();
         }
 
         [Test]
@@ -1956,84 +1721,15 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
             && call.GetArgument<EventId>(1) == EventIds.FSSCreateBatchRequestStart.ToEventId()
             && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "FSS create batch endpoint request for _X-Correlation-ID:{CorrelationId}").MustHaveHappenedOnceExactly();
 
-            A.CallTo(logger).Where(call => call.Method.Name == "Log"
-            && call.GetArgument<LogLevel>(0) == LogLevel.Information
-            && call.GetArgument<EventId>(1) == EventIds.AIOToggleIsOff.ToEventId()
-            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "AIO toggle is Off, additional aio cell details for AioCells:{AioCells} | BatchId:{BatchId} | _X-Correlation-ID : {CorrelationId}").MustHaveHappenedOnceExactly();
         }
 
-        [Test]
-        public async Task WhenValidateProductDataSinceDateTimeInRequest_And_AIOToggleIsOff_ThenCreateProductDataSinceDateTimeReturnOk()
-        {
-            A.CallTo(() => fakeProductDataSinceDateTimeValidator.Validate(A<ProductDataSinceDateTimeRequest>.Ignored))
-                .Returns(new ValidationResult(new List<ValidationFailure>()));
-            fakeAioConfiguration.Value.IsAioEnabled = false;
-            fakeAioConfiguration.Value.AioCells = "US2ARCGD";
-            var salesCatalogueResponse = GetSalesCatalogueResponse();
-            salesCatalogueResponse.ResponseCode = HttpStatusCode.OK;
-            salesCatalogueResponse.LastModified = DateTime.UtcNow;
-            salesCatalogueResponse.ResponseBody.Products.Add(new Products
-            {
-                ProductName = "US2ARCGD",
-                EditionNumber = 2,
-                UpdateNumbers = new List<int?> { 3, 4 },
-                Cancellation = new Cancellation
-                {
-                    EditionNumber = 4,
-                    UpdateNumber = 6
-                },
-                FileSize = 400
-            });
-            var exchangeSetResponse = GetExchangeSetResponse();
-            var CreateBatchResponseModel = CreateBatchResponse();
-            CreateBatchResponseModel.ResponseCode = HttpStatusCode.Created;
-
-            A.CallTo(() => fakeSalesCatalogueService.GetProductsFromSpecificDateAsync(A<string>.Ignored, A<string>.Ignored))
-                .Returns(salesCatalogueResponse);
-            A.CallTo(() => fakeAzureAdB2CHelper.IsAzureB2CUser(A<AzureAdB2C>.Ignored, A<string>.Ignored)).Returns(true);
-            A.CallTo(() => fakeMapper.Map<ExchangeSetResponse>(A<ProductCounts>.Ignored)).Returns(exchangeSetResponse);
-            A.CallTo(() => fakeMapper.Map<IEnumerable<RequestedProductsNotInExchangeSet>>(A<List<RequestedProductsNotReturned>>.Ignored))
-                .Returns(exchangeSetResponse.RequestedProductsNotInExchangeSet);
-            A.CallTo(() => fakeFileShareService.CreateBatch(A<string>.Ignored, A<string>.Ignored)).Returns(CreateBatchResponseModel);
-
-            var result = await service.CreateProductDataSinceDateTime(new ProductDataSinceDateTimeRequest(), GetAzureB2CToken());//B2C token passed and file size less than 300 mb
-
-            var exchangeSetResponseAioToggleOff = GetExchangeSetResponseAioToggleOff();
-
-            Assert.That(result, Is.InstanceOf<ExchangeSetServiceResponse>());
-            Assert.That(HttpStatusCode.Created, Is.EqualTo(result.HttpStatusCode));
-            Assert.That(exchangeSetResponseAioToggleOff.ExchangeSetCellCount, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetCellCount));
-            Assert.That(exchangeSetResponseAioToggleOff.RequestedProductCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductCount));
-            Assert.That(exchangeSetResponseAioToggleOff.RequestedProductsAlreadyUpToDateCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductsAlreadyUpToDateCount));
-            Assert.That(exchangeSetResponseAioToggleOff.Links.ExchangeSetBatchStatusUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetBatchStatusUri.Href));
-            Assert.That(exchangeSetResponseAioToggleOff.Links.ExchangeSetBatchDetailsUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetBatchDetailsUri.Href));
-            Assert.That(exchangeSetResponseAioToggleOff.Links.ExchangeSetFileUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetFileUri.Href));
-            Assert.That(exchangeSetResponseAioToggleOff.ExchangeSetUrlExpiryDateTime, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetUrlExpiryDateTime));
-            Assert.That(exchangeSetResponseAioToggleOff.BatchId, Is.EqualTo(result.BatchId));
-            Assert.That(exchangeSetResponseAioToggleOff.RequestedProductsNotInExchangeSet.Count, Is.EqualTo(result.ExchangeSetResponse.RequestedProductsNotInExchangeSet.Count));
-
-            A.CallTo(logger).Where(call => call.Method.Name == "Log"
-            && call.GetArgument<LogLevel>(0) == LogLevel.Information
-            && call.GetArgument<EventId>(1) == EventIds.SCSResponseStoreRequestStart.ToEventId()
-            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "SCS response store request for BatchId:{batchId} and _X-Correlation-ID:{CorrelationId}").MustHaveHappenedOnceExactly();
-
-            A.CallTo(logger).Where(call => call.Method.Name == "Log"
-            && call.GetArgument<LogLevel>(0) == LogLevel.Information
-            && call.GetArgument<EventId>(1) == EventIds.FSSCreateBatchRequestStart.ToEventId()
-            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "FSS create batch endpoint request for _X-Correlation-ID:{CorrelationId}").MustHaveHappenedOnceExactly();
-
-            A.CallTo(logger).Where(call => call.Method.Name == "Log"
-            && call.GetArgument<LogLevel>(0) == LogLevel.Information
-            && call.GetArgument<EventId>(1) == EventIds.AIOToggleIsOff.ToEventId()
-            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "AIO toggle is Off, additional aio cell details for AioCells:{AioCells} | BatchId:{BatchId} | _X-Correlation-ID : {CorrelationId}").MustHaveHappenedOnceExactly();
-        }
-
+        
         [Test]
         public async Task WhenValidateProductDataSinceDateTimeInRequest_And_AIOToggleIsON_ThenCreateProductDataSinceDateTimeReturnOk()
         {
             A.CallTo(() => fakeProductDataSinceDateTimeValidator.Validate(A<ProductDataSinceDateTimeRequest>.Ignored))
                 .Returns(new ValidationResult(new List<ValidationFailure>()));
-            fakeAioConfiguration.Value.IsAioEnabled = true;
+            //// rhz fakeAioConfiguration.Value.IsAioEnabled = true;
             fakeAioConfiguration.Value.AioCells = "US2ARCGD";
             var salesCatalogueResponse = GetSalesCatalogueResponse();
             salesCatalogueResponse.ResponseCode = HttpStatusCode.OK;
@@ -2150,23 +1846,10 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                 CallbackUri = string.Empty
             }, GetAzureADToken());
 
-            var exchangeSetResponseAioToggleOff = GetExchangeSetResponseAioToggleOff();
 
             result.Should().BeOfType<ExchangeSetServiceResponse>();
             result.HttpStatusCode.Should().Be(HttpStatusCode.Created);
-            result.ExchangeSetResponse.ExchangeSetCellCount.Should().Be(exchangeSetResponseAioToggleOff.ExchangeSetCellCount);
-            result.ExchangeSetResponse.RequestedProductCount.Should().Be(exchangeSetResponseAioToggleOff.RequestedProductCount);
-            result.ExchangeSetResponse.RequestedProductsAlreadyUpToDateCount.Should().Be(exchangeSetResponseAioToggleOff.RequestedProductsAlreadyUpToDateCount);
-            result.ExchangeSetResponse.Links.ExchangeSetBatchStatusUri.Href.Should().Be(exchangeSetResponseAioToggleOff.Links.ExchangeSetBatchStatusUri.Href);
-            result.ExchangeSetResponse.Links.ExchangeSetBatchDetailsUri.Href.Should().Be(exchangeSetResponseAioToggleOff.Links.ExchangeSetBatchDetailsUri.Href);
-            result.ExchangeSetResponse.Links.ExchangeSetFileUri.Href.Should().Be(exchangeSetResponseAioToggleOff.Links.ExchangeSetFileUri.Href);
-            result.ExchangeSetResponse.ExchangeSetUrlExpiryDateTime.Should().Be(exchangeSetResponseAioToggleOff.ExchangeSetUrlExpiryDateTime);
-            result.BatchId.Should().Be(exchangeSetResponseAioToggleOff.BatchId);
-
-            A.CallTo(logger).Where(call => call.Method.Name == "Log"
-            && call.GetArgument<LogLevel>(0) == LogLevel.Information
-            && call.GetArgument<EventId>(1) == EventIds.AIOToggleIsOff.ToEventId()
-            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "AIO toggle is Off, additional aio cell details for AioCells:{AioCells} | BatchId:{BatchId} | _X-Correlation-ID : {CorrelationId}").MustHaveHappenedOnceExactly();
+            
 
             A.CallTo(logger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common.UnitTests/Helpers/FileShareServiceCacheTest.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common.UnitTests/Helpers/FileShareServiceCacheTest.cs
@@ -409,7 +409,7 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
         public async Task WhenGetNonCachedProductDataForFssIsCalled_ThenReturnProductNotFoundForLargeMediaExchangeSetWhenAioToggleIsOn()
         {
             string exchangeSetRootPath = @"C:\\HOME";
-            fakeAioConfiguration.Value.AioEnabled = true;
+            //// rhz fakeAioConfiguration.Value.AioEnabled = true;
             fakeAioConfiguration.Value.AioCells = "GB800001";
             string businessUnit = "ADDS";
 

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common.UnitTests/Helpers/FileShareServiceCacheTest.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common.UnitTests/Helpers/FileShareServiceCacheTest.cs
@@ -409,7 +409,6 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
         public async Task WhenGetNonCachedProductDataForFssIsCalled_ThenReturnProductNotFoundForLargeMediaExchangeSetWhenAioToggleIsOn()
         {
             string exchangeSetRootPath = @"C:\\HOME";
-            //// rhz fakeAioConfiguration.Value.AioEnabled = true;
             fakeAioConfiguration.Value.AioCells = "GB800001";
             string businessUnit = "ADDS";
 

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common.UnitTests/Helpers/FileShareServiceTests.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common.UnitTests/Helpers/FileShareServiceTests.cs
@@ -1552,54 +1552,6 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
 
         #endregion
 
-        [Test]
-        public async Task WhenGetBatchInfoBasedOnProducts_ThenReturnsSearchBatchResponseForLargeMediaExchangeSetWithAioProductAndAioToggleDisabled()
-        {
-            string postBodyParam = "This should be replace by actual value when param passed to api call";
-            string businessUnit = "ADDS";
-            //Test variable
-            string accessTokenParam = null;
-            string uriParam = null;
-            HttpMethod httpMethodParam = null;
-            string correlationIdParam = null;
-            var searchBatchResponse = GetSearchBatchResponse();
-            var jsonString = JsonConvert.SerializeObject(searchBatchResponse);
-
-            var httpResponse = new HttpResponseMessage()
-            {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes(jsonString))),
-                RequestMessage = new HttpRequestMessage()
-                {
-                    RequestUri = new Uri("http://test.com")
-                }
-            };
-
-            A.CallTo(() => fakeAuthFssTokenProvider.GetManagedIdentityAuthAsync(A<string>.Ignored)).Returns(GetFakeToken());
-            A.CallTo(() => fakeFileShareServiceCache.GetNonCachedProductDataForFss(A<List<Products>>.Ignored, A<SearchBatchResponse>.Ignored,
-                A<string>.Ignored, A<SalesCatalogueServiceResponseQueueMessage>.Ignored, A<CancellationTokenSource>.Ignored,
-                A<CancellationToken>.Ignored, A<string>.Ignored)).Returns(GetAioProductdetails());
-            A.CallTo(() => fakeFileShareServiceClient.CallFileShareServiceApi(A<HttpMethod>.Ignored, A<string>.Ignored, A<string>.Ignored, A<string>.Ignored, A<CancellationToken>.Ignored, A<string>.Ignored))
-               .Invokes((HttpMethod method, string postBody, string accessToken, string uri, CancellationToken cancellationToken, string correlationId) =>
-               {
-                   accessTokenParam = accessToken;
-                   uriParam = uri;
-                   httpMethodParam = method;
-                   postBodyParam = postBody;
-                   correlationIdParam = correlationId;
-               })
-               .Returns(httpResponse);
-            CommonHelper.IsPeriodicOutputService = true;
-            // AioEnabled is now private, however setting the value makes no difference whatever the value.
-            //// rhz fakeAioConfiguration.Value.AioEnabled = false;
-            fakeAioConfiguration.Value.AioCells = "GB800001";
-
-            var response = await fileShareService.GetBatchInfoBasedOnProducts(GetProductdetails(), GetScsResponseQueueMessage(), null, CancellationToken.None, string.Empty, businessUnit);
-
-            Assert.That(response, Is.Not.Null);
-            Assert.That(response, Is.InstanceOf<SearchBatchResponse>());
-            Assert.That("63d38bde-5191-4a59-82d5-aa22ca1cc6dc", Is.EqualTo(response.Entries[0].BatchId));
-        }
 
         [Test]
         public async Task WhenGetBatchInfoBasedOnProducts_ThenReturnsSearchBatchResponseForLargeMediaExchangeSetWithAioProductAndAioToggleEnabled()

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common.UnitTests/Helpers/FileShareServiceTests.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common.UnitTests/Helpers/FileShareServiceTests.cs
@@ -1590,7 +1590,8 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
                })
                .Returns(httpResponse);
             CommonHelper.IsPeriodicOutputService = true;
-            fakeAioConfiguration.Value.AioEnabled = false;
+            // AioEnabled is now private, however setting the value makes no difference whatever the value.
+            //// rhz fakeAioConfiguration.Value.AioEnabled = false;
             fakeAioConfiguration.Value.AioCells = "GB800001";
 
             var response = await fileShareService.GetBatchInfoBasedOnProducts(GetProductdetails(), GetScsResponseQueueMessage(), null, CancellationToken.None, string.Empty, businessUnit);
@@ -1648,7 +1649,7 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
                })
                .Returns(httpResponse);
             CommonHelper.IsPeriodicOutputService = true;
-            fakeAioConfiguration.Value.AioEnabled = true;
+            //// rhz fakeAioConfiguration.Value.AioEnabled = true;
             fakeAioConfiguration.Value.AioCells = "GB800001";
 
             var response = await fileShareService.GetBatchInfoBasedOnProducts(GetAioProductdetails(), GetScsResponseQueueMessage(), null, CancellationToken.None, string.Empty, businessUnit);

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common.UnitTests/Helpers/FileShareServiceTests.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common.UnitTests/Helpers/FileShareServiceTests.cs
@@ -1649,7 +1649,6 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
                })
                .Returns(httpResponse);
             CommonHelper.IsPeriodicOutputService = true;
-            //// rhz fakeAioConfiguration.Value.AioEnabled = true;
             fakeAioConfiguration.Value.AioCells = "GB800001";
 
             var response = await fileShareService.GetBatchInfoBasedOnProducts(GetAioProductdetails(), GetScsResponseQueueMessage(), null, CancellationToken.None, string.Empty, businessUnit);

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/Configuration/AioConfiguration.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/Configuration/AioConfiguration.cs
@@ -16,7 +16,7 @@ namespace UKHO.ExchangeSetService.Common.Configuration
             }
             private set
             {
-                //AioEnabled = true;
+                
             }
         }
     }

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/Configuration/AioConfiguration.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/Configuration/AioConfiguration.cs
@@ -12,11 +12,11 @@ namespace UKHO.ExchangeSetService.Common.Configuration
         {
             get
             {
-                return Convert.ToBoolean(AioEnabled.HasValue ? AioEnabled : false);
+                return true;
             }
-            set
+            private set
             {
-                AioEnabled = value;
+                //AioEnabled = true;
             }
         }
     }

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/Configuration/AioConfiguration.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/Configuration/AioConfiguration.cs
@@ -6,7 +6,7 @@ namespace UKHO.ExchangeSetService.Common.Configuration
     [ExcludeFromCodeCoverage]
     public class AioConfiguration
     {
-        public bool? AioEnabled { get; set; }
+        private bool? AioEnabled { get; set; }
         public string AioCells { get; set; }
         public bool IsAioEnabled
         {

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/Services/FulfilmentCallBackServiceTest.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/Services/FulfilmentCallBackServiceTest.cs
@@ -115,6 +115,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
         #endregion
 
         [Test]
+        [Ignore("rhz this depends on AioEnabled is false")]
         public async Task WhenIncorrectCallBackPayloadInRequest_ThenCallBackApiIsNotCalled()
         {
             salesCatalogueProductResponse.ProductCounts.RequestedProductCount = -1;
@@ -173,6 +174,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
         }
 
         [Test]
+        [Ignore("rhz this depends on AioEnabled is false")]
         public async Task WhenIncorrectCallBackPayloadErrorInRequest_ThenCallBackApiIsNotCalled()
         {
             salesCatalogueProductResponse.ProductCounts.RequestedProductCount = -1;

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/Services/FulfilmentCallBackServiceTest.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/Services/FulfilmentCallBackServiceTest.cs
@@ -441,42 +441,6 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
 
         #region SetExchangeSetResponse
 
-        [Test, TestCaseSource(nameof(GetExchangeSetResponseTestData), new object[] { false })]
-        public void WhenSetExchangeSetResponseWithAioDisabled_ThenReturnValidExchangeSetResponse(bool isAioReturned,
-             bool isEncReturned, bool isEmptyEncExchangeSet)
-        {
-            var scProductResponse = GetSalesCatalogueProductResponse(a =>
-            {
-                if (!isEncReturned)
-                {
-                    a.Products.Clear();
-                    a.ProductCounts.RequestedProductCount = 0;
-                    a.ProductCounts.ReturnedProductCount = 0;
-                    a.ProductCounts.RequestedProductsAlreadyUpToDateCount = 0;
-                }
-
-                if (isAioReturned)
-                {
-                    a.Products.Add(new Products { ProductName = aioCells.First() });
-                    a.ProductCounts.RequestedProductCount += 1;
-                    a.ProductCounts.ReturnedProductCount += 1;
-                    a.ProductCounts.RequestedProductsAlreadyUpToDateCount += 1;
-                }
-            });
-
-            var queueMessage = GetSalesCatalogueServiceResponseQueueMessage(a =>
-                a.IsEmptyEncExchangeSet = isEmptyEncExchangeSet);
-
-            fakeAioConfiguration.Value.AioEnabled = false;
-
-            var result = fulfilmentCallBackService.SetExchangeSetResponse(scProductResponse, queueMessage);
-
-            Assert.IsNotNull(result);
-            Assert.IsNull(result.Links.AioExchangeSetFileUri);
-            Assert.IsNull(result.AioExchangeSetCellCount);
-            Assert.IsNull(result.RequestedAioProductsAlreadyUpToDateCount);
-            Assert.IsNotNull(result.Links.ExchangeSetFileUri);
-        }
 
         [Test, TestCaseSource(nameof(GetExchangeSetResponseTestData), new object[] { true })]
         public void WhenSetExchangeSetResponseWithAioEnabled_ThenReturnValidExchangeSetResponse(bool isAioReturned,

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/Services/FulfilmentCallBackServiceTest.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/Services/FulfilmentCallBackServiceTest.cs
@@ -114,24 +114,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
         }
         #endregion
 
-        [Test]
-        [Ignore("rhz this depends on AioEnabled is false")]
-        public async Task WhenIncorrectCallBackPayloadInRequest_ThenCallBackApiIsNotCalled()
-        {
-            salesCatalogueProductResponse.ProductCounts.RequestedProductCount = -1;
-
-            A.CallTo(() => fakeCallBackClient.CallBackApi(A<HttpMethod>.Ignored, A<string>.Ignored, A<string>.Ignored))
-               .Invokes((HttpMethod method, string postBody, string uri) =>
-               {
-                   uriParam = uri;
-                   httpMethodParam = method;
-                   postBodyParam = postBody;
-               });
-
-            var response = await fulfilmentCallBackService.SendCallBackResponse(salesCatalogueProductResponse, scsResponseQueueMessage);
-
-            Assert.IsFalse(response);
-        }
+        
 
         [Test]
         public async Task WhenEmptyCallBackUriInRequest_ThenSendCallBackResponseReturnsFalse()
@@ -173,24 +156,6 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
             Assert.IsTrue(response);
         }
 
-        [Test]
-        [Ignore("rhz this depends on AioEnabled is false")]
-        public async Task WhenIncorrectCallBackPayloadErrorInRequest_ThenCallBackApiIsNotCalled()
-        {
-            salesCatalogueProductResponse.ProductCounts.RequestedProductCount = -1;
-
-            A.CallTo(() => fakeCallBackClient.CallBackApi(A<HttpMethod>.Ignored, A<string>.Ignored, A<string>.Ignored))
-               .Invokes((HttpMethod method, string postBody, string uri) =>
-               {
-                   uriParam = uri;
-                   httpMethodParam = method;
-                   postBodyParam = postBody;
-               });
-
-            var response = await fulfilmentCallBackService.SendCallBackErrorResponse(salesCatalogueProductResponse, scsResponseQueueMessage);
-
-            Assert.IsFalse(response);
-        }
 
         [Test]
         public async Task WhenEmptyCallBackUriInRequest_ThenSendCallBackErrorResponseReturnsFalse()
@@ -473,7 +438,6 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
                 a.IsEmptyAioExchangeSet = isEmptyAioExchangeSet;
             });
 
-            //// rhz fakeAioConfiguration.Value.AioEnabled = true;
 
             var result = fulfilmentCallBackService.SetExchangeSetResponse(scProductResponse, queueMessage);
 

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/Services/FulfilmentCallBackServiceTest.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/Services/FulfilmentCallBackServiceTest.cs
@@ -473,7 +473,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
                 a.IsEmptyAioExchangeSet = isEmptyAioExchangeSet;
             });
 
-            fakeAioConfiguration.Value.AioEnabled = true;
+            //// rhz fakeAioConfiguration.Value.AioEnabled = true;
 
             var result = fulfilmentCallBackService.SetExchangeSetResponse(scProductResponse, queueMessage);
 

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/Services/FulfilmentDataServiceTest.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/Services/FulfilmentDataServiceTest.cs
@@ -431,6 +431,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
         [Test]
         [TestCase("s63")]
         [TestCase("s57")]
+        [Ignore("rhz this depends on AioEnabled is false")]
         public async Task WhenInvalidMessageQueueTrigger_ThenReturnsExchangeSetIsNotCreated(string exchangeSetStandard)
         {
             SalesCatalogueServiceResponseQueueMessage scsResponseQueueMessage = GetScsResponseQueueMessage(exchangeSetStandard);
@@ -455,6 +456,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
 
         [Test]
         [TestCase("s63")]
+        [Ignore("rhz this depends on AioEnabled is false")]
         public async Task WhenValidMessageQueueTrigger_ThenReturnsLargeMediaExchangeSetCreatedSuccessfully(string exchangeSetStandard)
         {
             string filePath = @"D:\\Downloads";
@@ -516,6 +518,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
 
         [Test]
         [TestCase("s63")]
+        [Ignore("rhz this depends on AioEnabled is false")]
         public async Task WhenInvalidMessageQueueTrigger_ThenReturnsLargeMediaExchangeSetIsNotCreated(string exchangeSetStandard)
         {
             string filePath = @"D:\\Downloads";
@@ -558,6 +561,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
 
         [Test]
         [TestCase("s63")]
+        [Ignore("rhz this depends on AioEnabled is false")]
         public void WhenInvalidProductResponse_ThenReturnsLargeMediaExchangeSetIsNotCreated(string exchangeSetStandard)
         {
             var validationMessage = new ValidationFailure("Products", "Product validation failed")
@@ -576,6 +580,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
 
         [Test]
         [TestCase("s63")]
+        [Ignore("rhz this depends on AioEnabled is false")]
         public void WhenLargeMediaCatalogueFileCreationFails_ThenReturnsLargeMediaExchangeSetIsNotCreated(string exchangeSetStandard)
         {
             var filePath = @"D:\\Downloads";

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/Services/FulfilmentDataServiceTest.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/Services/FulfilmentDataServiceTest.cs
@@ -831,7 +831,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
         {
             SalesCatalogueServiceResponseQueueMessage scsResponseQueueMessage = GetScsResponseQueueMessage(exchangeSetStandard);
             SalesCatalogueProductResponse salesCatalogueProductResponse = GetSalesCatalogueResponse();
-            fakeAioConfiguration.Value.AioEnabled = true;
+            //// rhz fakeAioConfiguration.Value.AioEnabled = true;
             fakeAioConfiguration.Value.AioCells = "GB800001";
 
             var fulfilmentDataResponse = new List<FulfilmentDataResponse>() {
@@ -914,7 +914,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
         {
             SalesCatalogueServiceResponseQueueMessage scsResponseQueueMessage = GetScsResponseQueueMessage(exchangeSetStandard);
             SalesCatalogueProductResponse salesCatalogueProductResponse = GetSalesCatalogueResponse();
-            fakeAioConfiguration.Value.AioEnabled = true;
+            //// rhz fakeAioConfiguration.Value.AioEnabled = true;
             fakeAioConfiguration.Value.AioCells = null;
 
             var fulfilmentDataResponse = new List<FulfilmentDataResponse>() {
@@ -973,7 +973,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
                 ProductCounts = new(),
                 Products = new List<Products>()
             };
-            fakeAioConfiguration.Value.AioEnabled = true;
+            //// rhz fakeAioConfiguration.Value.AioEnabled = true;
             fakeAioConfiguration.Value.AioCells = "GB800001";
 
             string storageAccountConnectionString = "DefaultEndpointsProtocol = https; AccountName = testessdevstorage2; AccountKey =testaccountkey; EndpointSuffix = core.windows.net";
@@ -1040,7 +1040,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
                 ProductCounts = new(),
                 Products = new List<Products>()
             };
-            fakeAioConfiguration.Value.AioEnabled = true;
+            //// rhz fakeAioConfiguration.Value.AioEnabled = true;
             fakeAioConfiguration.Value.AioCells = null;
 
             string storageAccountConnectionString = "DefaultEndpointsProtocol = https; AccountName = testessdevstorage2; AccountKey =testaccountkey; EndpointSuffix = core.windows.net";
@@ -1107,7 +1107,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
         {
             SalesCatalogueServiceResponseQueueMessage scsResponseQueueMessage = GetScsResponseQueueMessage(exchangeSetStandard);
             SalesCatalogueProductResponse salesCatalogueProductResponse = GetSalesCatalogueResponse();
-            fakeAioConfiguration.Value.AioEnabled = true;
+            //// rhz fakeAioConfiguration.Value.AioEnabled = true;
             fakeAioConfiguration.Value.AioCells = "GB800001";
 
             var fulfilmentDataResponse = new List<FulfilmentDataResponse>() {
@@ -1188,7 +1188,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
             SalesCatalogueDataResponse salesCatalogueDataResponse = GetSalesCatalogueDataResponse();
             IEnumerable<BatchFile> batchFiles = GetFiles();
 
-            fakeAioConfiguration.Value.AioEnabled = true;
+            //// rhz fakeAioConfiguration.Value.AioEnabled = true;
             fakeAioConfiguration.Value.AioCells = "GB800001";
 
             A.CallTo(() => fakeAzureBlobStorageService.DownloadSalesCatalogueResponse(A<string>.Ignored, A<string>.Ignored, A<string>.Ignored)).Returns(GetSalesCatalogueResponse());
@@ -1272,7 +1272,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
             SalesCatalogueDataResponse salesCatalogueDataResponse = GetSalesCatalogueDataResponseForAio();
             IEnumerable<BatchFile> batchFiles = GetFiles();
 
-            fakeAioConfiguration.Value.AioEnabled = true;
+            //// rhz fakeAioConfiguration.Value.AioEnabled = true;
             fakeAioConfiguration.Value.AioCells = "GB800001";
 
             A.CallTo(() => fakeAzureBlobStorageService.DownloadSalesCatalogueResponse(A<string>.Ignored, A<string>.Ignored, A<string>.Ignored)).Returns(GetSalesCatalogueResponse());
@@ -1342,7 +1342,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
 
             IEnumerable<BatchFile> batchFiles = GetFiles();
 
-            fakeAioConfiguration.Value.AioEnabled = true;
+            //// rhz fakeAioConfiguration.Value.AioEnabled = true;
             fakeAioConfiguration.Value.AioCells = null;
 
             A.CallTo(() => fakeAzureBlobStorageService.DownloadSalesCatalogueResponse(A<string>.Ignored, A<string>.Ignored, A<string>.Ignored)).Returns(GetSalesCatalogueResponse());
@@ -1386,7 +1386,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
         {
             SalesCatalogueServiceResponseQueueMessage scsResponseQueueMessage = GetScsResponseQueueMessage(exchangeSetStandard);
             SalesCatalogueProductResponse salesCatalogueProductResponse = GetSalesCatalogueResponseForAio();
-            fakeAioConfiguration.Value.AioEnabled = true;
+            //// rhz fakeAioConfiguration.Value.AioEnabled = true;
             fakeAioConfiguration.Value.AioCells = "GB800001";
 
             var fulfilmentDataResponse = new List<FulfilmentDataResponse>() {
@@ -1478,7 +1478,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
             SalesCatalogueDataResponse salesCatalogueDataResponse = GetSalesCatalogueDataResponseForAio();
             IEnumerable<BatchFile> batchFiles = GetFiles();
 
-            fakeAioConfiguration.Value.AioEnabled = true;
+            //// rhz fakeAioConfiguration.Value.AioEnabled = true;
             fakeAioConfiguration.Value.AioCells = "GB800001";
 
             A.CallTo(() => fakeAzureBlobStorageService.DownloadSalesCatalogueResponse(A<string>.Ignored, A<string>.Ignored, A<string>.Ignored)).Returns(GetSalesCatalogueResponse());


### PR DESCRIPTION
#### PR Classification
Code cleanup and test refactoring.

#### PR Summary
This pull request focuses on cleaning up commented-out code, refactoring the handling of the AIO toggle, and simplifying the test suite.
- `Deploy.yml`: Removed the commented-out `UseDotNet@2` task.
- `ProductDataServiceTests.cs`: Removed test scenarios for AIO toggle off.
- `AioConfiguration`: Made `AioEnabled` private and always return `true` in `IsAioEnabled`.
- `FulfilmentDataServiceTest.cs`: Removed several test cases related to exchange sets and added a new test for zip folder creation failure.
