### PR TITLE
Remove AioEnabled flag from powershel and yml files

### DIFF
--- a/Deployment/set_api_webjob_aio_feature_configuration.ps1
+++ b/Deployment/set_api_webjob_aio_feature_configuration.ps1
@@ -2,19 +2,21 @@ param (
     [Parameter(Mandatory = $true)] [string] $resourcegroup,   
     [Parameter(Mandatory = $true)] [string] $webappname,
     [Parameter(Mandatory = $true)] [string[]] $fulfilmentwebappsname,
-    [Parameter(Mandatory = $true)] [string] $aioenabled,
+  ##  [Parameter(Mandatory = $true)] [string] $aioenabled,
     [Parameter(Mandatory = $true)] [string[]] $aiocells    
 )
 
 $aiocellsconfiguration = $aiocells -join ','
 
 Write-Output "Set ESS API Configuration in appsetting..."
-az webapp config appsettings set -g $resourcegroup -n $webappname --settings AioConfiguration:AioEnabled=$aioenabled AioConfiguration:AioCells=$aiocellsconfiguration
+## az webapp config appsettings set -g $resourcegroup -n $webappname --settings AioConfiguration:AioEnabled=$aioenabled AioConfiguration:AioCells=$aiocellsconfiguration
+az webapp config appsettings set -g $resourcegroup -n $webappname --settings AioConfiguration:AioCells=$aiocellsconfiguration
 az webapp restart --name $webappname --resource-group $resourcegroup
 
 Write-Output "Set Fulfilment Webjob Configuration in appsetting..."
 foreach($webapp in $fulfilmentwebappsname)
 {
-  az webapp config appsettings set -g $resourcegroup -n $webapp --settings AioConfiguration:AioEnabled=$aioenabled AioConfiguration:AioCells=$aiocellsconfiguration
+  ## az webapp config appsettings set -g $resourcegroup -n $webapp --settings AioConfiguration:AioEnabled=$aioenabled AioConfiguration:AioCells=$aiocellsconfiguration
+  az webapp config appsettings set -g $resourcegroup -n $webapp --settings AioConfiguration:AioCells=$aiocellsconfiguration
   az webapp restart --name $webapp --resource-group $resourcegroup
 }

--- a/Deployment/set_api_webjob_aio_feature_configuration.ps1
+++ b/Deployment/set_api_webjob_aio_feature_configuration.ps1
@@ -2,21 +2,18 @@ param (
     [Parameter(Mandatory = $true)] [string] $resourcegroup,   
     [Parameter(Mandatory = $true)] [string] $webappname,
     [Parameter(Mandatory = $true)] [string[]] $fulfilmentwebappsname,
-  ##  [Parameter(Mandatory = $true)] [string] $aioenabled,
     [Parameter(Mandatory = $true)] [string[]] $aiocells    
 )
 
 $aiocellsconfiguration = $aiocells -join ','
 
 Write-Output "Set ESS API Configuration in appsetting..."
-## az webapp config appsettings set -g $resourcegroup -n $webappname --settings AioConfiguration:AioEnabled=$aioenabled AioConfiguration:AioCells=$aiocellsconfiguration
 az webapp config appsettings set -g $resourcegroup -n $webappname --settings AioConfiguration:AioCells=$aiocellsconfiguration
 az webapp restart --name $webappname --resource-group $resourcegroup
 
 Write-Output "Set Fulfilment Webjob Configuration in appsetting..."
 foreach($webapp in $fulfilmentwebappsname)
 {
-  ## az webapp config appsettings set -g $resourcegroup -n $webapp --settings AioConfiguration:AioEnabled=$aioenabled AioConfiguration:AioCells=$aiocellsconfiguration
   az webapp config appsettings set -g $resourcegroup -n $webapp --settings AioConfiguration:AioCells=$aiocellsconfiguration
   az webapp restart --name $webapp --resource-group $resourcegroup
 }

--- a/Deployment/templates/Deploy.yml
+++ b/Deployment/templates/Deploy.yml
@@ -151,7 +151,7 @@ jobs:
               scriptType: 'pscore'
               scriptLocation: 'scriptPath'
               scriptPath: "$(Build.SourcesDirectory)/terraformartifact/set_api_webjob_aio_feature_configuration.ps1"
-              arguments: '-aiocells $(AioConfiguration.AioCells_FT) -aioenabled "true" -resourcegroup $(SetPipelineVariable.RESOURCE_GROUP_NAME) -webappname $(SetPipelineVariable.WEB_APP_NAME) -fulfilmentwebappsname $(fulfilmentWebAppsName)'
+              arguments: '-aiocells $(AioConfiguration.AioCells_FT) -resourcegroup $(SetPipelineVariable.RESOURCE_GROUP_NAME) -webappname $(SetPipelineVariable.WEB_APP_NAME) -fulfilmentwebappsname $(fulfilmentWebAppsName)'
 
           - task: DotNetCoreCLI@2
             displayName: "Run Functional tests AIOEnabled"
@@ -172,7 +172,7 @@ jobs:
               scriptType: 'pscore'
               scriptLocation: 'scriptPath'
               scriptPath: "$(Build.SourcesDirectory)/terraformartifact/set_api_webjob_aio_feature_configuration.ps1"
-              arguments: '-aiocells $(AioConfiguration.AioCells_FT) -aioenabled "false" -resourcegroup $(SetPipelineVariable.RESOURCE_GROUP_NAME) -webappname $(SetPipelineVariable.WEB_APP_NAME) -fulfilmentwebappsname $(fulfilmentWebAppsName)'
+              arguments: '-aiocells $(AioConfiguration.AioCells_FT) -resourcegroup $(SetPipelineVariable.RESOURCE_GROUP_NAME) -webappname $(SetPipelineVariable.WEB_APP_NAME) -fulfilmentwebappsname $(fulfilmentWebAppsName)'
 
           - task: DotNetCoreCLI@2
             displayName: "Run Functional tests AIODisabled"
@@ -194,4 +194,4 @@ jobs:
               scriptType: 'pscore'
               scriptLocation: 'scriptPath'
               scriptPath: "$(Build.SourcesDirectory)/terraformartifact/set_api_webjob_aio_feature_configuration.ps1"
-              arguments: '-aiocells $(AioConfiguration.AioCells) -aioenabled $(AioConfiguration.AioEnabled) -resourcegroup $(SetPipelineVariable.RESOURCE_GROUP_NAME) -webappname $(SetPipelineVariable.WEB_APP_NAME) -fulfilmentwebappsname $(fulfilmentWebAppsName)'
+              arguments: '-aiocells $(AioConfiguration.AioCells) -resourcegroup $(SetPipelineVariable.RESOURCE_GROUP_NAME) -webappname $(SetPipelineVariable.WEB_APP_NAME) -fulfilmentwebappsname $(fulfilmentWebAppsName)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -505,7 +505,7 @@ stages:
                     scriptType: 'pscore'
                     scriptLocation: 'scriptPath'
                     scriptPath: "$(Build.SourcesDirectory)/terraformartifact/set_api_webjob_aio_feature_configuration.ps1"
-                    arguments: '-aiocells $(AioConfiguration.AioCells_FT) -aioenabled "true" -resourcegroup $(RESOURCE_GROUP_NAME) -webappname $(WEB_APP_NAME) -fulfilmentwebappsname $(fulfilmentWebAppsName)'
+                    arguments: '-aiocells $(AioConfiguration.AioCells_FT) -resourcegroup $(RESOURCE_GROUP_NAME) -webappname $(WEB_APP_NAME) -fulfilmentwebappsname $(fulfilmentWebAppsName)'
 
                 - task: DotNetCoreCLI@2
                   displayName: "Run Functional"
@@ -527,7 +527,7 @@ stages:
                     scriptType: 'pscore'
                     scriptLocation: 'scriptPath'
                     scriptPath: "$(Build.SourcesDirectory)/terraformartifact/set_api_webjob_aio_feature_configuration.ps1"
-                    arguments: '-aiocells $(AioConfiguration.AioCells_FT) -aioenabled $(AioConfiguration.AioEnabled) -resourcegroup $(RESOURCE_GROUP_NAME) -webappname $(WEB_APP_NAME) -fulfilmentwebappsname $(fulfilmentWebAppsName)'
+                    arguments: '-aiocells $(AioConfiguration.AioCells_FT) -resourcegroup $(RESOURCE_GROUP_NAME) -webappname $(WEB_APP_NAME) -fulfilmentwebappsname $(fulfilmentWebAppsName)'
 
       - deployment: DevDeployApp2
         dependsOn:
@@ -672,7 +672,7 @@ stages:
                     scriptType: 'pscore'
                     scriptLocation: 'scriptPath'
                     scriptPath: "$(Build.SourcesDirectory)/terraformartifact/set_api_webjob_aio_feature_configuration.ps1"
-                    arguments: '-aiocells $(AioConfiguration.AioCells_FT) -aioenabled "true" -resourcegroup $(webAppResourceGroup) -webappname $(essWebAppName) -fulfilmentwebappsname $(essFulfilmentWebAppname)'
+                    arguments: '-aiocells $(AioConfiguration.AioCells_FT) -resourcegroup $(webAppResourceGroup) -webappname $(essWebAppName) -fulfilmentwebappsname $(essFulfilmentWebAppname)'
 
                 - task: DotNetCoreCLI@2
                   displayName: "Run Functional tests AIOEnabled"
@@ -694,7 +694,7 @@ stages:
                     scriptType: 'pscore'
                     scriptLocation: 'scriptPath'
                     scriptPath: "$(Build.SourcesDirectory)/terraformartifact/set_api_webjob_aio_feature_configuration.ps1"
-                    arguments: '-aiocells $(AioConfiguration.AioCells) -aioenabled $(AioConfiguration.AioEnabled) -resourcegroup $(webAppResourceGroup) -webappname $(essWebAppName) -fulfilmentwebappsname $(essFulfilmentWebAppname)'
+                    arguments: '-aiocells $(AioConfiguration.AioCells) -resourcegroup $(webAppResourceGroup) -webappname $(essWebAppName) -fulfilmentwebappsname $(essFulfilmentWebAppname)'
 
   - stage: QAdeploy
     dependsOn:
@@ -790,7 +790,7 @@ stages:
                     scriptType: 'pscore'
                     scriptLocation: 'scriptPath'
                     scriptPath: "$(Build.SourcesDirectory)/terraformartifact/set_api_webjob_aio_feature_configuration.ps1"
-                    arguments: '-aiocells $(AioConfiguration.AioCells) -aioenabled $(AioConfiguration.AioEnabled) -resourcegroup $(RESOURCE_GROUP_NAME) -webappname $(WEB_APP_NAME) -fulfilmentwebappsname $(fulfilmentWebAppsName)'
+                    arguments: '-aiocells $(AioConfiguration.AioCells) -resourcegroup $(RESOURCE_GROUP_NAME) -webappname $(WEB_APP_NAME) -fulfilmentwebappsname $(fulfilmentWebAppsName)'
 
       - deployment: QADeployApp2
         dependsOn:
@@ -1030,7 +1030,7 @@ stages:
                     scriptType: 'pscore'
                     scriptLocation: 'scriptPath'
                     scriptPath: "$(Build.SourcesDirectory)/terraformartifact/set_api_webjob_aio_feature_configuration.ps1"
-                    arguments: '-aiocells $(AioConfiguration.AioCells) -aioenabled $(AioConfiguration.AioEnabled) -resourcegroup $(RESOURCE_GROUP_NAME) -webappname $(WEB_APP_NAME) -fulfilmentwebappsname $(fulfilmentWebAppsName)'
+                    arguments: '-aiocells $(AioConfiguration.AioCells) -resourcegroup $(RESOURCE_GROUP_NAME) -webappname $(WEB_APP_NAME) -fulfilmentwebappsname $(fulfilmentWebAppsName)'
 
   - stage: vnexte2eDeploy
     dependsOn: 
@@ -1122,4 +1122,4 @@ stages:
                     scriptType: 'pscore'
                     scriptLocation: 'scriptPath'
                     scriptPath: "$(Build.SourcesDirectory)/terraformartifact/set_api_webjob_aio_feature_configuration.ps1"
-                    arguments: '-aiocells $(AioConfiguration.AioCells) -aioenabled $(AioConfiguration.AioEnabled) -resourcegroup $(RESOURCE_GROUP_NAME) -webappname $(WEB_APP_NAME) -fulfilmentwebappsname $(fulfilmentWebAppsName)'
+                    arguments: '-aiocells $(AioConfiguration.AioCells) -resourcegroup $(RESOURCE_GROUP_NAME) -webappname $(WEB_APP_NAME) -fulfilmentwebappsname $(fulfilmentWebAppsName)'


### PR DESCRIPTION
#### PR Classification
Code cleanup to streamline configuration by removing the `aioenabled` parameter.

#### PR Summary
This pull request removes the `aioenabled` parameter and its associated settings from the configuration scripts and pipeline files.
- `set_api_webjob_aio_feature_configuration.ps1`: Removed `aioenabled` parameter and related settings.
- `Deploy.yml`: Updated script execution arguments to remove `-aioenabled` parameter.
- `azure-pipelines.yml`: Updated script execution arguments to remove `-aioenabled` parameter.
- `Deploy.yml` and `azure-pipelines.yml`: Removed `DotNetCoreCLI@2` tasks for `AioEnabled` and `AioDisabled` configurations.
