### PR TITLE
Update from main 14/01/2025

### DIFF
--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/UKHO.ExchangeSetService.API.FunctionalTests.csproj
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/UKHO.ExchangeSetService.API.FunctionalTests.csproj
@@ -19,8 +19,12 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.66.2" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.67.1" />
     <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.56.0.67649">

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Controllers/EssWebhookControllerTests.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Controllers/EssWebhookControllerTests.cs
@@ -1,4 +1,9 @@
-﻿using FakeItEasy;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using FakeItEasy;
 using FluentAssertions;
 using FluentValidation.Results;
 using Microsoft.AspNetCore.Http;
@@ -6,11 +11,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Threading.Tasks;
 using UKHO.ExchangeSetService.API.Controllers;
 using UKHO.ExchangeSetService.API.Services;
 using UKHO.ExchangeSetService.Common.Helpers;
@@ -21,7 +21,6 @@ using Attribute = UKHO.ExchangeSetService.Common.Models.Request.Attribute;
 
 namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 {
-
     [TestFixture]
     public class EssWebhookControllerTests
     {
@@ -53,7 +52,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 
             var result = (OkObjectResult)fakeWebHookController.NewFilesPublishedOptions();
 
-            Assert.That(200, Is.EqualTo(result.StatusCode));
+            Assert.That(result.StatusCode, Is.EqualTo(200));
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
               && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -65,9 +64,12 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
               && call.GetArgument<EventId>(1) == EventIds.NewFilesPublishedWebhookOptionsCallCompleted.ToEventId()
               && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2)!.ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Completed processing the Options request for the New Files Published event webhook for WebHook-Request-Origin:{webhookRequestOrigin}").MustHaveHappenedOnceExactly();
 
-            Assert.That(responseHeaders.Count, Is.EqualTo(2));
-            Assert.That(responseHeaders["WebHook-Allowed-Rate"].ToString(), Is.EqualTo("*"));
-            Assert.That(responseHeaders["WebHook-Allowed-Origin"].ToString(), Is.EqualTo("test.com"));
+            Assert.That(responseHeaders, Has.Count.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(responseHeaders["WebHook-Allowed-Rate"].ToString(), Is.EqualTo("*"));
+                Assert.That(responseHeaders["WebHook-Allowed-Origin"].ToString(), Is.EqualTo("test.com"));
+            });
         }
 
         [Test]
@@ -85,7 +87,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
             A.CallTo(() => fakeEssWebhookService.ValidateEventGridCacheDataRequest(A<EnterpriseEventCacheDataRequest>.Ignored)).MustNotHaveHappened();
             A.CallTo(() => fakeEssWebhookService.InvalidateAndInsertCacheDataAsync(A<EnterpriseEventCacheDataRequest>.Ignored, A<string>.Ignored)).MustNotHaveHappened();
 
-            Assert.That(200, Is.EqualTo(result.StatusCode));
+            Assert.That(result.StatusCode, Is.EqualTo(200));
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
               && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -124,7 +126,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 
             A.CallTo(() => fakeEssWebhookService.InvalidateAndInsertCacheDataAsync(A<EnterpriseEventCacheDataRequest>.Ignored, A<string>.Ignored)).MustNotHaveHappened();
 
-            Assert.That(200, Is.EqualTo(result.StatusCode));
+            Assert.That(result.StatusCode, Is.EqualTo(200));
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
               && call.GetArgument<LogLevel>(0) == LogLevel.Information

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Controllers/ProductDataControllerTests.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Controllers/ProductDataControllerTests.cs
@@ -1,15 +1,15 @@
-﻿using FakeItEasy;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using FakeItEasy;
 using FluentAssertions;
 using FluentValidation.Results;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Threading.Tasks;
 using UKHO.ExchangeSetService.API.Controllers;
 using UKHO.ExchangeSetService.API.Services;
 using UKHO.ExchangeSetService.Common.Logging;
@@ -117,8 +117,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 
             var result = (BadRequestObjectResult)await controller.PostProductIdentifiers(productIdentifiers, callbackUri, exchangeSetStandard.ToString().ToString());
             var errors = (ErrorDescription)result.Value;
-            Assert.That(400, Is.EqualTo(result.StatusCode));
-            Assert.That("Product Identifiers cannot be null or empty.", Is.EqualTo(errors.Errors.Single().Description));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.StatusCode, Is.EqualTo(400));
+                Assert.That(errors.Errors.Single().Description, Is.EqualTo("Product Identifiers cannot be null or empty."));
+            });
         }
 
         [Test]
@@ -144,8 +147,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 
             var result = (BadRequestObjectResult)await controller.PostProductIdentifiers(null, null, exchangeSetStandard.ToString());
             var errors = (ErrorDescription)result.Value;
-            Assert.That(400, Is.EqualTo(result.StatusCode));
-            Assert.That("Either body is null or malformed.", Is.EqualTo(errors.Errors.Single().Description));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.StatusCode, Is.EqualTo(400));
+                Assert.That(errors.Errors.Single().Description, Is.EqualTo("Either body is null or malformed."));
+            });
         }
 
         [Test]
@@ -174,9 +180,12 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 
             var result = (BadRequestObjectResult)await controller.PostProductIdentifiers(productIdentifiers, callbackUri, exchangeSetStandard.ToString());
             var errors = (ErrorDescription)result.Value;
-            Assert.That(400, Is.EqualTo(result.StatusCode));
-            Assert.That("requestBody", Is.EqualTo(errors.Errors.Single().Source));
-            Assert.That("Either body is null or malformed.", Is.EqualTo(errors.Errors.Single().Description));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.StatusCode, Is.EqualTo(400));
+                Assert.That(errors.Errors.Single().Source, Is.EqualTo("requestBody"));
+                Assert.That(errors.Errors.Single().Description, Is.EqualTo("Either body is null or malformed."));
+            });
         }
 
         [Test]
@@ -204,10 +213,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
             string callbackUri = string.Empty;
 
             var result = (ObjectResult)await controller.PostProductIdentifiers(productIdentifiers, callbackUri, exchangeSetStandard.ToString());
-            
-            Assert.That("Internal Server Error", Is.SameAs(((UKHO.ExchangeSetService.Common.Models.Response.InternalServerError)result.Value).Detail));
-
-            Assert.That(500, Is.EqualTo(result.StatusCode));
+            Assert.Multiple(() =>
+            {
+                Assert.That(((InternalServerError)result.Value).Detail, Is.SameAs("Internal Server Error"));
+                Assert.That(result.StatusCode, Is.EqualTo(500));
+            });
         }
 
         [Test]
@@ -235,7 +245,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
             string callbackUri = string.Empty;
 
             var result = (StatusCodeResult)await controller.PostProductIdentifiers(productIdentifiers, callbackUri, exchangeSetStandard.ToString());
-            Assert.That(304, Is.EqualTo(result.StatusCode));
+            Assert.That(result.StatusCode, Is.EqualTo(304));
         }
 
         [Test]
@@ -369,8 +379,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 
             var errors = (ErrorDescription)result.Value;
 
-            Assert.That(400, Is.EqualTo(result.StatusCode));
-            Assert.That("productName cannot be blank or null.", Is.EqualTo(errors.Errors.Single().Description));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.StatusCode, Is.EqualTo(400));
+                Assert.That(errors.Errors.Single().Description, Is.EqualTo("productName cannot be blank or null."));
+            });
         }
 
         [Test]
@@ -399,9 +412,12 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
             var result = (BadRequestObjectResult)await controller.PostProductDataByProductVersions(new List<ProductVersionRequest>(), "", exchangeSetStandard.ToString());
             var errors = (ErrorDescription)result.Value;
 
-            Assert.That(400, Is.EqualTo(result.StatusCode));
-            Assert.That("requestBody", Is.EqualTo(errors.Errors.Single().Source));
-            Assert.That("Either body is null or malformed.", Is.EqualTo(errors.Errors.Single().Description));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.StatusCode, Is.EqualTo(400));
+                Assert.That(errors.Errors.Single().Source, Is.EqualTo("requestBody"));
+                Assert.That(errors.Errors.Single().Description, Is.EqualTo("Either body is null or malformed."));
+            });
         }
 
         [Test]
@@ -428,8 +444,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
             var result = (ObjectResult)await controller.PostProductDataByProductVersions(new List<ProductVersionRequest>()
                             { new ProductVersionRequest() { ProductName = "demo" } }, "", exchangeSetStandard.ToString());
 
-            Assert.That("Internal Server Error", Is.SameAs(((UKHO.ExchangeSetService.Common.Models.Response.InternalServerError)result.Value).Detail));
-            Assert.That(500, Is.EqualTo(result.StatusCode));
+            Assert.Multiple(() =>
+            {
+                Assert.That(((InternalServerError)result.Value).Detail, Is.SameAs("Internal Server Error"));
+                Assert.That(result.StatusCode, Is.EqualTo(500));
+            });
         }
 
         [Test]
@@ -455,7 +474,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 
             var result = (StatusCodeResult)await controller.PostProductDataByProductVersions(new List<ProductVersionRequest>()
                             { new ProductVersionRequest() { ProductName = "demo" } }, "", exchangeSetStandard.ToString());
-            Assert.That(304, Is.EqualTo(result.StatusCode));
+            Assert.That(result.StatusCode, Is.EqualTo(304));
         }
 
         [Test]
@@ -539,11 +558,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 
             A.CallTo(() => fakeProductDataService.CreateProductDataByProductVersions(A<ProductDataProductVersionsRequest>.Ignored, A<AzureAdB2C>.Ignored))
                  .Returns(exchangeSetServiceResponse);
-            
+
             var result = (OkObjectResult)await controller.PostProductDataByProductVersions(new List<ProductVersionRequest>()
                             { new ProductVersionRequest() { ProductName = "demo" } }, "", exchangeSetStandard.ToString());
             Assert.That(exchangeSetServiceResponse.ExchangeSetResponse, Is.SameAs(result.Value));
-            
+
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
             && call.GetArgument<EventId>(1) == EventIds.ESSPostProductVersionsRequestStart.ToEventId()
@@ -580,9 +599,12 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
             var result = (BadRequestObjectResult)await controller.GetProductDataSinceDateTime(null, "https://www.abc.com", exchangeSetStandard.ToString());
             var errors = (ErrorDescription)result.Value;
 
-            Assert.That(400, Is.EqualTo(result.StatusCode));
-            Assert.That("sinceDateTime", Is.EqualTo(errors.Errors.Single().Source));
-            Assert.That("Query parameter 'sinceDateTime' is required.", Is.EqualTo(errors.Errors.Single().Description));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.StatusCode, Is.EqualTo(400));
+                Assert.That(errors.Errors.Single().Source, Is.EqualTo("sinceDateTime"));
+                Assert.That(errors.Errors.Single().Description, Is.EqualTo("Query parameter 'sinceDateTime' is required."));
+            });
         }
 
         [Test]
@@ -608,8 +630,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 
             var result = (ObjectResult)await controller.GetProductDataSinceDateTime("Wed, 21 Oct 2015 07:28:00 GMT", "https://www.abc.com", exchangeSetStandard.ToString());
 
-            Assert.That("Internal Server Error", Is.SameAs(((UKHO.ExchangeSetService.Common.Models.Response.InternalServerError)result.Value).Detail));
-            Assert.That(500, Is.EqualTo(result.StatusCode));
+            Assert.Multiple(() =>
+            {
+                Assert.That(((InternalServerError)result.Value).Detail, Is.SameAs("Internal Server Error"));
+                Assert.That(result.StatusCode, Is.EqualTo(500));
+            });
         }
 
         [Test]
@@ -634,7 +659,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
                .Returns(exchangeSetServiceResponse);
 
             var result = (StatusCodeResult)await controller.GetProductDataSinceDateTime("Wed, 21 Oct 2015 07:28:00 GMT", "https://www.abc.com", exchangeSetStandard.ToString());
-            Assert.That(304, Is.EqualTo(result.StatusCode));
+            Assert.That(result.StatusCode, Is.EqualTo(304));
         }
 
         [Test]
@@ -719,8 +744,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 
             var result = (OkObjectResult)await controller.GetProductDataSinceDateTime("Wed, 21 Oct 2015 07:28:00 GMT", "https://www.abc.com", exchangeSetStandard.ToString());
 
-            Assert.That(exchangeSetServiceResponse.ExchangeSetResponse.ExchangeSetCellCount, Is.EqualTo(((UKHO.ExchangeSetService.Common.Models.Response.ExchangeSetResponse)result.Value).ExchangeSetCellCount));
-            Assert.That(200, Is.EqualTo(result.StatusCode));
+            Assert.Multiple(() =>
+            {
+                Assert.That(((ExchangeSetResponse)result.Value).ExchangeSetCellCount, Is.EqualTo(exchangeSetServiceResponse.ExchangeSetResponse.ExchangeSetCellCount));
+                Assert.That(result.StatusCode, Is.EqualTo(200));
+            });
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Services/ProductDataServiceTests.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Services/ProductDataServiceTests.cs
@@ -1,15 +1,15 @@
-﻿using AutoMapper;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using AutoMapper;
 using FakeItEasy;
 using FluentAssertions;
 using FluentValidation.Results;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Threading.Tasks;
 using UKHO.ExchangeSetService.API.Configuration;
 using UKHO.ExchangeSetService.API.Services;
 using UKHO.ExchangeSetService.API.Validation;
@@ -378,8 +378,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
 
             var result = await service.ValidateProductDataByProductIdentifiers(new ProductIdentifierRequest());
 
-            Assert.That(result.IsValid,Is.False);
-            Assert.That("Product Identifiers cannot be blank or null.", Is.EqualTo(result.Errors.Single().ErrorMessage));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.IsValid, Is.False);
+                Assert.That(result.Errors.Single().ErrorMessage, Is.EqualTo("Product Identifiers cannot be blank or null."));
+            });
         }
 
         [Test]
@@ -390,8 +393,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                     {new ValidationFailure("RequestBody", "Either body is null or malformed.")}));
 
             var result = await service.ValidateProductDataByProductIdentifiers(null);
-            Assert.That(result.IsValid, Is.False);
-            Assert.That("Either body is null or malformed.", Is.EqualTo(result.Errors.Single().ErrorMessage));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.IsValid, Is.False);
+                Assert.That(result.Errors.Single().ErrorMessage, Is.EqualTo("Either body is null or malformed."));
+            });
         }
 
         [Test]
@@ -413,7 +419,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
 
                 });
 
-            Assert.That(result.IsValid,Is.True);
+            Assert.That(result.IsValid, Is.True);
         }
 
         [Test]
@@ -438,8 +444,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                     CallbackUri = callbackUri
                 }, azureB2CToken); //B2C Token with file Size less than 300 mb
 
-            Assert.That(result, Is.InstanceOf<ExchangeSetServiceResponse>());
-            Assert.That(HttpStatusCode.BadRequest, Is.EqualTo(result.HttpStatusCode));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.InstanceOf<ExchangeSetServiceResponse>());
+                Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+            });
         }
 
         [Test]
@@ -464,8 +473,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                     CallbackUri = callbackUri
                 }, azureAdB2CToken); //AdB2C token with file size large than 300 mb
 
-            Assert.That(result, Is.InstanceOf<ExchangeSetServiceResponse>());
-            Assert.That(HttpStatusCode.BadRequest, Is.EqualTo(result.HttpStatusCode));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.InstanceOf<ExchangeSetServiceResponse>());
+                Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+            });
         }
 
         [Test]
@@ -479,7 +491,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
             string callbackUri = string.Empty;
             var salesCatalogueResponse = GetSalesCatalogueResponse();
             var azureAdToken = GetAzureADToken();
-            
+
 
             A.CallTo(() => fakeSalesCatalogueService.PostProductIdentifiersAsync(A<List<string>>.Ignored, A<string>.Ignored))
                 .Returns(salesCatalogueResponse);
@@ -505,7 +517,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                     ExchangeSetStandard = exchangeSetStandard.ToString()
                 }, azureAdToken);
 
-            Assert.That(HttpStatusCode.Created, Is.EqualTo(result.HttpStatusCode));
+            Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.Created));
 
             A.CallTo(logger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -549,10 +561,12 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                     CallbackUri = callbackUri
                 }, azureB2CToken); // AzureB2C Token but file size is less than 300 Mb
 
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.Created));
+                Assert.That(result.LastModified, Is.Not.Null);
+            });
 
-            Assert.That(HttpStatusCode.Created, Is.EqualTo(result.HttpStatusCode));
-            Assert.That(result.LastModified, Is.Not.Null);
-            
             A.CallTo(logger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
             && call.GetArgument<EventId>(1) == EventIds.FSSCreateBatchRequestStart.ToEventId()
@@ -589,8 +603,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                     CallbackUri = callbackUri
                 }, azureAdB2CToken);//azure Ad B2C token when file size is less than 300 Mb
 
-            Assert.That(result, Is.InstanceOf<ExchangeSetServiceResponse>());
-            Assert.That(HttpStatusCode.InternalServerError, Is.EqualTo(result.HttpStatusCode));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.InstanceOf<ExchangeSetServiceResponse>());
+                Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.InternalServerError));
+            });
         }
 
         [Test]
@@ -631,8 +648,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                     ExchangeSetStandard = exchangeSetStandard.ToString()
                 }, azureAdToken);
 
-            Assert.That(result.ExchangeSetResponse, Is.Null);
-            Assert.That(HttpStatusCode.InternalServerError, Is.EqualTo(result.HttpStatusCode));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ExchangeSetResponse, Is.Null);
+                Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.InternalServerError));
+            });
         }
 
         [Test]
@@ -684,7 +704,6 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
             A.CallTo(() => fakeExchangeSetStorageProvider.SaveSalesCatalogueStorageDetails(salesCatalogueResponse.ResponseBody, CreateBatchResponseModel.ResponseBody.BatchId, callBackUri, A<string>.Ignored, correlationId, A<string>.Ignored, salesCatalogueResponse.ScsRequestDateTime, A<bool>.Ignored, A<bool>.Ignored, A<ExchangeSetResponse>.Ignored)).MustNotHaveHappened();
         }
 
-        
         [Test]
         public async Task WhenValidProductIdentifierRequest_And_AIOToggleIsOn_ThenCreateProductDataByProductIdentifierReturnsOkrequest()
         {
@@ -737,21 +756,24 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
 
             var exchangeSetResponseAioToggleOn = GetExchangeSetResponseAioToggleON();
 
-            Assert.That(HttpStatusCode.Created, Is.EqualTo(result.HttpStatusCode));
-            Assert.That(exchangeSetResponseAioToggleOn.ExchangeSetCellCount, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetCellCount));
-            Assert.That(exchangeSetResponseAioToggleOn.RequestedProductCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductCount));
-            Assert.That(exchangeSetResponseAioToggleOn.RequestedProductsAlreadyUpToDateCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductsAlreadyUpToDateCount));
-            Assert.That(exchangeSetResponseAioToggleOn.Links.ExchangeSetBatchStatusUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetBatchStatusUri.Href));
-            Assert.That(exchangeSetResponseAioToggleOn.Links.ExchangeSetBatchDetailsUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetBatchDetailsUri.Href));
-            Assert.That(exchangeSetResponseAioToggleOn.Links.ExchangeSetFileUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetFileUri.Href));
-            Assert.That(exchangeSetResponseAioToggleOn.ExchangeSetUrlExpiryDateTime, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetUrlExpiryDateTime));
-            Assert.That(exchangeSetResponseAioToggleOn.BatchId, Is.EqualTo(result.BatchId));
-            //Aio cell details
-            Assert.That(exchangeSetResponseAioToggleOn.AioExchangeSetCellCount, Is.EqualTo(result.ExchangeSetResponse.AioExchangeSetCellCount));
-            Assert.That(exchangeSetResponseAioToggleOn.RequestedAioProductCount, Is.EqualTo(result.ExchangeSetResponse.RequestedAioProductCount));
-            Assert.That(exchangeSetResponseAioToggleOn.RequestedAioProductsAlreadyUpToDateCount, Is.EqualTo(result.ExchangeSetResponse.RequestedAioProductsAlreadyUpToDateCount));
-            Assert.That(exchangeSetResponseAioToggleOn.RequestedProductsNotInExchangeSet.Count, Is.EqualTo(result.ExchangeSetResponse.RequestedProductsNotInExchangeSet.Count));
-            Assert.That(exchangeSetResponseAioToggleOn.Links.AioExchangeSetFileUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.AioExchangeSetFileUri.Href));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.Created));
+                Assert.That(exchangeSetResponseAioToggleOn.ExchangeSetCellCount, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetCellCount));
+                Assert.That(exchangeSetResponseAioToggleOn.RequestedProductCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductCount));
+                Assert.That(exchangeSetResponseAioToggleOn.RequestedProductsAlreadyUpToDateCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductsAlreadyUpToDateCount));
+                Assert.That(exchangeSetResponseAioToggleOn.Links.ExchangeSetBatchStatusUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetBatchStatusUri.Href));
+                Assert.That(exchangeSetResponseAioToggleOn.Links.ExchangeSetBatchDetailsUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetBatchDetailsUri.Href));
+                Assert.That(exchangeSetResponseAioToggleOn.Links.ExchangeSetFileUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetFileUri.Href));
+                Assert.That(exchangeSetResponseAioToggleOn.ExchangeSetUrlExpiryDateTime, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetUrlExpiryDateTime));
+                Assert.That(exchangeSetResponseAioToggleOn.BatchId, Is.EqualTo(result.BatchId));
+                //Aio cell details
+                Assert.That(exchangeSetResponseAioToggleOn.AioExchangeSetCellCount, Is.EqualTo(result.ExchangeSetResponse.AioExchangeSetCellCount));
+                Assert.That(exchangeSetResponseAioToggleOn.RequestedAioProductCount, Is.EqualTo(result.ExchangeSetResponse.RequestedAioProductCount));
+                Assert.That(exchangeSetResponseAioToggleOn.RequestedAioProductsAlreadyUpToDateCount, Is.EqualTo(result.ExchangeSetResponse.RequestedAioProductsAlreadyUpToDateCount));
+                Assert.That(exchangeSetResponseAioToggleOn.RequestedProductsNotInExchangeSet, Has.Count.EqualTo(result.ExchangeSetResponse.RequestedProductsNotInExchangeSet.Count));
+                Assert.That(exchangeSetResponseAioToggleOn.Links.AioExchangeSetFileUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.AioExchangeSetFileUri.Href));
+            });
 
             A.CallTo(logger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -853,8 +875,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
             var result = await service.ValidateProductDataByProductVersions(new ProductDataProductVersionsRequest()
             { ProductVersions = new List<ProductVersionRequest>() { new ProductVersionRequest() { ProductName = null } } });
 
-            Assert.That(result.IsValid, Is.False);
-            Assert.That("productName cannot be blank or null.", Is.EqualTo(result.Errors.Single().ErrorMessage));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.IsValid, Is.False);
+                Assert.That(result.Errors.Single().ErrorMessage, Is.EqualTo("productName cannot be blank or null."));
+            });
         }
 
         [Test]
@@ -866,8 +891,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
 
             var result = await service.ValidateProductDataByProductVersions(null);
 
-            Assert.That(result.IsValid, Is.False);
-            Assert.That("Either body is null or malformed.", Is.EqualTo(result.Errors.Single().ErrorMessage));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.IsValid, Is.False);
+                Assert.That(result.Errors.Single().ErrorMessage, Is.EqualTo("Either body is null or malformed."));
+            });
         }
 
         [Test]
@@ -879,7 +907,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
             var result = await service.ValidateProductDataByProductVersions(new ProductDataProductVersionsRequest()
             { ProductVersions = new List<ProductVersionRequest>() { new ProductVersionRequest() { ProductName = "Demo", EditionNumber = 5, UpdateNumber = 0 } } });
 
-            Assert.That(result.IsValid,Is.True);
+            Assert.That(result.IsValid, Is.True);
         }
 
         [Test]
@@ -900,8 +928,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                 CallbackUri = ""
             }, azureB2CToken);//valid AzureAdB2c Token , but filesize is large than 300 mb
 
-            Assert.That(result, Is.InstanceOf<ExchangeSetServiceResponse>());
-            Assert.That(HttpStatusCode.BadRequest, Is.EqualTo(result.HttpStatusCode));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.InstanceOf<ExchangeSetServiceResponse>());
+                Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+            });
         }
 
         [Test]
@@ -922,8 +953,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                 CallbackUri = ""
             }, azureAdB2CToken);//valid AzureAdB2c Token , but filesize is large than 300 mb
 
-            Assert.That(result, Is.InstanceOf<ExchangeSetServiceResponse>());
-            Assert.That(HttpStatusCode.BadRequest, Is.EqualTo(result.HttpStatusCode));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.InstanceOf<ExchangeSetServiceResponse>());
+                Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+            });
         }
 
         [Test]
@@ -934,7 +968,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
             A.CallTo(() => fakeProductVersionValidator.Validate(A<ProductDataProductVersionsRequest>.Ignored))
                 .Returns(new ValidationResult(new List<ValidationFailure>()));
             var salesCatalogueResponse = GetSalesCatalogueResponse();
-            var azureAdToken = GetAzureADToken();           
+            var azureAdToken = GetAzureADToken();
 
             A.CallTo(() => fakeSalesCatalogueService.PostProductVersionsAsync(A<List<ProductVersionRequest>>.Ignored, A<string>.Ignored))
                 .Returns(salesCatalogueResponse);
@@ -968,7 +1002,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
             }, azureAdToken);
 
 
-            Assert.That(HttpStatusCode.Created, Is.EqualTo(result.HttpStatusCode));
+            Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.Created));
 
             A.CallTo(logger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -1020,13 +1054,16 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
             exchangeSetResponseAioToggleOff.RequestedProductsAlreadyUpToDateCount = 3;//RequestedProductsAlreadyUpToDateCount
 
             Assert.That(result, Is.InstanceOf<ExchangeSetServiceResponse>());
-            Assert.That(HttpStatusCode.Created, Is.EqualTo(result.HttpStatusCode));
-            Assert.That(result.LastModified,Is.Null);
-            Assert.That(exchangeSetResponseAioToggleOff.ExchangeSetCellCount, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetCellCount));
-            Assert.That(exchangeSetResponseAioToggleOff.RequestedProductCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductCount));
-            Assert.That(exchangeSetResponseAioToggleOff.RequestedProductsAlreadyUpToDateCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductsAlreadyUpToDateCount));
-            Assert.That(exchangeSetResponseAioToggleOff.ExchangeSetUrlExpiryDateTime, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetUrlExpiryDateTime));
-            Assert.That(exchangeSetResponseAioToggleOff.BatchId, Is.EqualTo(result.BatchId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.Created));
+                Assert.That(result.LastModified, Is.Null);
+                Assert.That(exchangeSetResponseAioToggleOff.ExchangeSetCellCount, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetCellCount));
+                Assert.That(exchangeSetResponseAioToggleOff.RequestedProductCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductCount));
+                Assert.That(exchangeSetResponseAioToggleOff.RequestedProductsAlreadyUpToDateCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductsAlreadyUpToDateCount));
+                Assert.That(exchangeSetResponseAioToggleOff.ExchangeSetUrlExpiryDateTime, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetUrlExpiryDateTime));
+                Assert.That(exchangeSetResponseAioToggleOff.BatchId, Is.EqualTo(result.BatchId));
+            });
 
             A.CallTo(logger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -1080,13 +1117,16 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
             exchangeSetResponseAioToggleOff.RequestedProductsAlreadyUpToDateCount = 3;//RequestedProductsAlreadyUpToDateCount
 
             Assert.That(result, Is.InstanceOf<ExchangeSetServiceResponse>());
-            Assert.That(HttpStatusCode.Created, Is.EqualTo(result.HttpStatusCode));
-            Assert.That(result.LastModified,Is.Not.Null);
-            Assert.That(exchangeSetResponseAioToggleOff.ExchangeSetCellCount, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetCellCount));
-            Assert.That(exchangeSetResponseAioToggleOff.RequestedProductCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductCount));
-            Assert.That(exchangeSetResponseAioToggleOff.RequestedProductsAlreadyUpToDateCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductsAlreadyUpToDateCount));
-            Assert.That(exchangeSetResponseAioToggleOff.ExchangeSetUrlExpiryDateTime, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetUrlExpiryDateTime));
-            Assert.That(exchangeSetResponseAioToggleOff.BatchId, Is.EqualTo(result.BatchId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.Created));
+                Assert.That(result.LastModified, Is.Not.Null);
+                Assert.That(exchangeSetResponseAioToggleOff.ExchangeSetCellCount, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetCellCount));
+                Assert.That(exchangeSetResponseAioToggleOff.RequestedProductCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductCount));
+                Assert.That(exchangeSetResponseAioToggleOff.RequestedProductsAlreadyUpToDateCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductsAlreadyUpToDateCount));
+                Assert.That(exchangeSetResponseAioToggleOff.ExchangeSetUrlExpiryDateTime, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetUrlExpiryDateTime));
+                Assert.That(exchangeSetResponseAioToggleOff.BatchId, Is.EqualTo(result.BatchId));
+            });
 
             A.CallTo(logger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -1124,8 +1164,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
             }, azureADToken);
 
             Assert.That(result, Is.InstanceOf<ExchangeSetServiceResponse>());
-            Assert.That(HttpStatusCode.InternalServerError, Is.EqualTo(result.HttpStatusCode));
-            Assert.That(result.LastModified,Is.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.InternalServerError));
+                Assert.That(result.LastModified, Is.Null);
+            });
         }
 
         [Test]
@@ -1163,8 +1206,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                 ExchangeSetStandard = exchangeSetStandard.ToString()
             }, azureAdToken);
 
-            Assert.That(result.ExchangeSetResponse,Is.Null);
-            Assert.That(HttpStatusCode.InternalServerError, Is.EqualTo(result.HttpStatusCode));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ExchangeSetResponse, Is.Null);
+                Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.InternalServerError));
+            });
         }
 
         [Test]
@@ -1218,10 +1264,8 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
             && call.GetArgument<EventId>(1) == EventIds.FSSCreateBatchRequestStart.ToEventId()
             && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "FSS create batch endpoint request for _X-Correlation-ID:{CorrelationId}").MustHaveHappenedOnceExactly();
-
         }
 
-        
         [Test]
         public async Task WhenValidProductVersionRequestWithExchangeSetStandardS57_AndFileSizeIsMoreThan700Mb_ThenCreateProductDataByProductVersionsReturnsBadRequest()
         {
@@ -1357,21 +1401,24 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
             var exchangeSetResponseAioToggleOn = GetExchangeSetResponseAioToggleON();
 
             Assert.That(result, Is.InstanceOf<ExchangeSetServiceResponse>());
-            Assert.That(HttpStatusCode.Created, Is.EqualTo(result.HttpStatusCode));
-            Assert.That(exchangeSetResponseAioToggleOn.ExchangeSetCellCount, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetCellCount));
-            Assert.That(exchangeSetResponseAioToggleOn.RequestedProductCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductCount));
-            Assert.That(exchangeSetResponseAioToggleOn.RequestedProductsAlreadyUpToDateCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductsAlreadyUpToDateCount));
-            Assert.That(exchangeSetResponseAioToggleOn.Links.ExchangeSetBatchStatusUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetBatchStatusUri.Href));
-            Assert.That(exchangeSetResponseAioToggleOn.Links.ExchangeSetBatchDetailsUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetBatchDetailsUri.Href));
-            Assert.That(exchangeSetResponseAioToggleOn.Links.ExchangeSetFileUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetFileUri.Href));
-            Assert.That(exchangeSetResponseAioToggleOn.ExchangeSetUrlExpiryDateTime, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetUrlExpiryDateTime));
-            Assert.That(exchangeSetResponseAioToggleOn.BatchId, Is.EqualTo(result.BatchId));
-            //Aio cell details
-            Assert.That(exchangeSetResponseAioToggleOn.AioExchangeSetCellCount, Is.EqualTo(result.ExchangeSetResponse.AioExchangeSetCellCount));
-            Assert.That(exchangeSetResponseAioToggleOn.RequestedAioProductCount, Is.EqualTo(result.ExchangeSetResponse.RequestedAioProductCount));
-            Assert.That(exchangeSetResponseAioToggleOn.RequestedAioProductsAlreadyUpToDateCount, Is.EqualTo(result.ExchangeSetResponse.RequestedAioProductsAlreadyUpToDateCount));
-            Assert.That(exchangeSetResponseAioToggleOn.RequestedProductsNotInExchangeSet.Count, Is.EqualTo(result.ExchangeSetResponse.RequestedProductsNotInExchangeSet.Count));
-            Assert.That(exchangeSetResponseAioToggleOn.Links.AioExchangeSetFileUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.AioExchangeSetFileUri.Href));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.Created));
+                Assert.That(exchangeSetResponseAioToggleOn.ExchangeSetCellCount, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetCellCount));
+                Assert.That(exchangeSetResponseAioToggleOn.RequestedProductCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductCount));
+                Assert.That(exchangeSetResponseAioToggleOn.RequestedProductsAlreadyUpToDateCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductsAlreadyUpToDateCount));
+                Assert.That(exchangeSetResponseAioToggleOn.Links.ExchangeSetBatchStatusUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetBatchStatusUri.Href));
+                Assert.That(exchangeSetResponseAioToggleOn.Links.ExchangeSetBatchDetailsUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetBatchDetailsUri.Href));
+                Assert.That(exchangeSetResponseAioToggleOn.Links.ExchangeSetFileUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetFileUri.Href));
+                Assert.That(exchangeSetResponseAioToggleOn.ExchangeSetUrlExpiryDateTime, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetUrlExpiryDateTime));
+                Assert.That(exchangeSetResponseAioToggleOn.BatchId, Is.EqualTo(result.BatchId));
+                //Aio cell details
+                Assert.That(exchangeSetResponseAioToggleOn.AioExchangeSetCellCount, Is.EqualTo(result.ExchangeSetResponse.AioExchangeSetCellCount));
+                Assert.That(exchangeSetResponseAioToggleOn.RequestedAioProductCount, Is.EqualTo(result.ExchangeSetResponse.RequestedAioProductCount));
+                Assert.That(exchangeSetResponseAioToggleOn.RequestedAioProductsAlreadyUpToDateCount, Is.EqualTo(result.ExchangeSetResponse.RequestedAioProductsAlreadyUpToDateCount));
+                Assert.That(exchangeSetResponseAioToggleOn.RequestedProductsNotInExchangeSet, Has.Count.EqualTo(result.ExchangeSetResponse.RequestedProductsNotInExchangeSet.Count));
+                Assert.That(exchangeSetResponseAioToggleOn.Links.AioExchangeSetFileUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.AioExchangeSetFileUri.Href));
+            });
 
             A.CallTo(logger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -1402,8 +1449,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
 
             var result = await service.ValidateScsProductDataByProductIdentifiers(new ScsProductIdentifierRequest());
 
-            Assert.That(result.IsValid, Is.False);
-            Assert.That("Product Identifiers cannot be blank or null.", Is.EqualTo(result.Errors.Single().ErrorMessage));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.IsValid, Is.False);
+                Assert.That(result.Errors.Single().ErrorMessage, Is.EqualTo("Product Identifiers cannot be blank or null."));
+            });
         }
 
         [Test]
@@ -1414,8 +1464,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                     {new ValidationFailure("RequestBody", "Either body is null or malformed.")}));
 
             var result = await service.ValidateScsProductDataByProductIdentifiers(null);
-            Assert.That(result.IsValid, Is.False);
-            Assert.That("Either body is null or malformed.", Is.EqualTo(result.Errors.Single().ErrorMessage));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.IsValid, Is.False);
+                Assert.That(result.Errors.Single().ErrorMessage, Is.EqualTo("Either body is null or malformed."));
+            });
         }
 
         [Test]
@@ -1452,7 +1505,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                     ProductIdentifier = productIdentifiers
                 });
 
-            Assert.That(HttpStatusCode.OK, Is.EqualTo(result.ResponseCode));
+            Assert.That(result.ResponseCode, Is.EqualTo(HttpStatusCode.OK));
         }
 
         [Test]
@@ -1473,7 +1526,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                     ProductIdentifier = productIdentifiers
                 });
 
-            Assert.That(HttpStatusCode.BadRequest, Is.EqualTo(result.ResponseCode));
+            Assert.That(result.ResponseCode, Is.EqualTo(HttpStatusCode.BadRequest));
         }
 
         #endregion ScsValidateProductIndentifier
@@ -1489,8 +1542,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
 
             var result = await service.ValidateProductDataSinceDateTime(new ProductDataSinceDateTimeRequest());
 
-            Assert.That(result.IsValid, Is.False);
-            Assert.That("Provided sinceDateTime is either invalid or invalid format, the valid format is 'RFC1123 format'.", Is.EqualTo(result.Errors.Single().ErrorMessage));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.IsValid, Is.False);
+                Assert.That(result.Errors.Single().ErrorMessage, Is.EqualTo("Provided sinceDateTime is either invalid or invalid format, the valid format is 'RFC1123 format'."));
+            });
         }
 
         [Test]
@@ -1502,8 +1558,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
 
             var result = await service.ValidateProductDataSinceDateTime(new ProductDataSinceDateTimeRequest());
 
-            Assert.That(result.IsValid, Is.False);
-            Assert.That("Provided sinceDateTime cannot be a future date.", Is.EqualTo(result.Errors.Single().ErrorMessage));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.IsValid, Is.False);
+                Assert.That(result.Errors.Single().ErrorMessage, Is.EqualTo("Provided sinceDateTime cannot be a future date."));
+            });
         }
 
         [Test]
@@ -1515,8 +1574,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
 
             var result = await service.ValidateProductDataSinceDateTime(new ProductDataSinceDateTimeRequest());
 
-            Assert.That(result.IsValid, Is.False);
-            Assert.That("Invalid callbackUri format.", Is.EqualTo(result.Errors.Single().ErrorMessage));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.IsValid, Is.False);
+                Assert.That(result.Errors.Single().ErrorMessage, Is.EqualTo("Invalid callbackUri format."));
+            });
         }
 
         [Test]
@@ -1529,7 +1591,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
             var salesCatalogueResponse = GetSalesCatalogueResponse();
             salesCatalogueResponse.LastModified = DateTime.UtcNow;
             var exchangeSetResponse = GetExchangeSetResponse();
-            var CreateBatchResponseModel = CreateBatchResponse();           
+            var CreateBatchResponseModel = CreateBatchResponse();
 
             A.CallTo(() => fakeSalesCatalogueService.GetProductsFromSpecificDateAsync(A<string>.Ignored, A<string>.Ignored))
                 .Returns(salesCatalogueResponse);
@@ -1545,10 +1607,8 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                 CallbackUri = string.Empty
             }, GetAzureADToken());
 
-
             result.Should().BeOfType<ExchangeSetServiceResponse>();
             result.HttpStatusCode.Should().Be(HttpStatusCode.Created);
-            
 
             A.CallTo(logger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -1600,7 +1660,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
             var result = await service.CreateProductDataSinceDateTime(new ProductDataSinceDateTimeRequest(), GetAzureB2CToken());// B2C token passed and file size large than 300 mb
 
             Assert.That(result, Is.InstanceOf<ExchangeSetServiceResponse>());
-            Assert.That(HttpStatusCode.BadRequest, Is.EqualTo(result.HttpStatusCode));
+            Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
         }
 
         [Test]
@@ -1619,7 +1679,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
             var result = await service.CreateProductDataSinceDateTime(new ProductDataSinceDateTimeRequest(), GetAzureAdB2CToken());//AdB2C token passed and file size large than 300 mb
 
             Assert.That(result, Is.InstanceOf<ExchangeSetServiceResponse>());
-            Assert.That(HttpStatusCode.BadRequest, Is.EqualTo(result.HttpStatusCode));
+            Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
         }
 
         [Test]
@@ -1644,10 +1704,8 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
 
             var result = await service.CreateProductDataSinceDateTime(new ProductDataSinceDateTimeRequest(), GetAzureB2CToken());//B2C token passed and file size less than 300 mb
 
-
             Assert.That(result, Is.InstanceOf<ExchangeSetServiceResponse>());
-            Assert.That(HttpStatusCode.Created, Is.EqualTo(result.HttpStatusCode));
-            
+            Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.Created));
 
             A.CallTo(logger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -1658,7 +1716,6 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
             && call.GetArgument<EventId>(1) == EventIds.FSSCreateBatchRequestStart.ToEventId()
             && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "FSS create batch endpoint request for _X-Correlation-ID:{CorrelationId}").MustHaveHappenedOnceExactly();
-
         }
 
         [Test]
@@ -1679,8 +1736,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
 
             var result = await service.CreateProductDataSinceDateTime(new ProductDataSinceDateTimeRequest(), GetAzureAdB2CToken());// ADB2C Token with File size less than 300 mb
 
-            Assert.That(result.ExchangeSetResponse, Is.Null);
-            Assert.That(HttpStatusCode.InternalServerError, Is.EqualTo(result.HttpStatusCode));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ExchangeSetResponse, Is.Null);
+                Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.InternalServerError));
+            });
         }
 
         [Test]
@@ -1718,10 +1778,8 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
             && call.GetArgument<EventId>(1) == EventIds.FSSCreateBatchRequestStart.ToEventId()
             && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "FSS create batch endpoint request for _X-Correlation-ID:{CorrelationId}").MustHaveHappenedOnceExactly();
-
         }
 
-        
         [Test]
         public async Task WhenValidateProductDataSinceDateTimeInRequest_And_AIOToggleIsON_ThenCreateProductDataSinceDateTimeReturnOk()
         {
@@ -1767,20 +1825,23 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
             exchangeSetResponseAioToggleOn.RequestedAioProductCount = 0;
 
             Assert.That(result, Is.InstanceOf<ExchangeSetServiceResponse>());
-            Assert.That(HttpStatusCode.Created, Is.EqualTo(result.HttpStatusCode));
-            Assert.That(exchangeSetResponseAioToggleOn.ExchangeSetCellCount, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetCellCount));
-            Assert.That(exchangeSetResponseAioToggleOn.RequestedProductCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductCount));
-            Assert.That(exchangeSetResponseAioToggleOn.RequestedProductsAlreadyUpToDateCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductsAlreadyUpToDateCount));
-            Assert.That(exchangeSetResponseAioToggleOn.Links.ExchangeSetBatchStatusUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetBatchStatusUri.Href));
-            Assert.That(exchangeSetResponseAioToggleOn.Links.ExchangeSetBatchDetailsUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetBatchDetailsUri.Href));
-            Assert.That(exchangeSetResponseAioToggleOn.ExchangeSetUrlExpiryDateTime, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetUrlExpiryDateTime));
-            Assert.That(exchangeSetResponseAioToggleOn.BatchId, Is.EqualTo(result.BatchId));
-            //Aio cell details
-            Assert.That(exchangeSetResponseAioToggleOn.AioExchangeSetCellCount, Is.EqualTo(result.ExchangeSetResponse.AioExchangeSetCellCount));
-            Assert.That(exchangeSetResponseAioToggleOn.RequestedAioProductCount, Is.EqualTo(result.ExchangeSetResponse.RequestedAioProductCount));
-            Assert.That(exchangeSetResponseAioToggleOn.RequestedAioProductsAlreadyUpToDateCount, Is.EqualTo(result.ExchangeSetResponse.RequestedAioProductsAlreadyUpToDateCount));
-            Assert.That(exchangeSetResponseAioToggleOn.RequestedProductsNotInExchangeSet.Count, Is.EqualTo(result.ExchangeSetResponse.RequestedProductsNotInExchangeSet.Count));
-            Assert.That(exchangeSetResponseAioToggleOn.Links.AioExchangeSetFileUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.AioExchangeSetFileUri.Href));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.Created));
+                Assert.That(exchangeSetResponseAioToggleOn.ExchangeSetCellCount, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetCellCount));
+                Assert.That(exchangeSetResponseAioToggleOn.RequestedProductCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductCount));
+                Assert.That(exchangeSetResponseAioToggleOn.RequestedProductsAlreadyUpToDateCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductsAlreadyUpToDateCount));
+                Assert.That(exchangeSetResponseAioToggleOn.Links.ExchangeSetBatchStatusUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetBatchStatusUri.Href));
+                Assert.That(exchangeSetResponseAioToggleOn.Links.ExchangeSetBatchDetailsUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.ExchangeSetBatchDetailsUri.Href));
+                Assert.That(exchangeSetResponseAioToggleOn.ExchangeSetUrlExpiryDateTime, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetUrlExpiryDateTime));
+                Assert.That(exchangeSetResponseAioToggleOn.BatchId, Is.EqualTo(result.BatchId));
+                //Aio cell details
+                Assert.That(exchangeSetResponseAioToggleOn.AioExchangeSetCellCount, Is.EqualTo(result.ExchangeSetResponse.AioExchangeSetCellCount));
+                Assert.That(exchangeSetResponseAioToggleOn.RequestedAioProductCount, Is.EqualTo(result.ExchangeSetResponse.RequestedAioProductCount));
+                Assert.That(exchangeSetResponseAioToggleOn.RequestedAioProductsAlreadyUpToDateCount, Is.EqualTo(result.ExchangeSetResponse.RequestedAioProductsAlreadyUpToDateCount));
+                Assert.That(exchangeSetResponseAioToggleOn.RequestedProductsNotInExchangeSet, Has.Count.EqualTo(result.ExchangeSetResponse.RequestedProductsNotInExchangeSet.Count));
+                Assert.That(exchangeSetResponseAioToggleOn.Links.AioExchangeSetFileUri.Href, Is.EqualTo(result.ExchangeSetResponse.Links.AioExchangeSetFileUri.Href));
+            });
 
             A.CallTo(logger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -1843,10 +1904,8 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                 CallbackUri = string.Empty
             }, GetAzureADToken());
 
-
             result.Should().BeOfType<ExchangeSetServiceResponse>();
             result.HttpStatusCode.Should().Be(HttpStatusCode.Created);
-            
 
             A.CallTo(logger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -1893,7 +1952,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
 
             var result = await service.GetProductDataSinceDateTime(new ProductDataSinceDateTimeRequest());
 
-            Assert.That(HttpStatusCode.OK, Is.EqualTo(result.ResponseCode));
+            Assert.That(result.ResponseCode, Is.EqualTo(HttpStatusCode.OK));
         }
 
         [Test]
@@ -1905,8 +1964,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
 
             var result = await service.ValidateScsDataSinceDateTime(new ProductDataSinceDateTimeRequest());
 
-            Assert.That(result.IsValid, Is.False);
-            Assert.That("Provided sinceDateTime is either invalid or invalid format, the valid format is 'RFC1123 format'.", Is.EqualTo(result.Errors.Single().ErrorMessage));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.IsValid, Is.False);
+                Assert.That(result.Errors.Single().ErrorMessage, Is.EqualTo("Provided sinceDateTime is either invalid or invalid format, the valid format is 'RFC1123 format'."));
+            });
         }
 
         [Test]
@@ -1918,11 +1980,13 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
 
             var result = await service.ValidateScsDataSinceDateTime(new ProductDataSinceDateTimeRequest());
 
-            Assert.That(result.IsValid, Is.False);
-            Assert.That("Provided sinceDateTime cannot be a future date.", Is.EqualTo(result.Errors.Single().ErrorMessage));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.IsValid, Is.False);
+                Assert.That(result.Errors.Single().ErrorMessage, Is.EqualTo("Provided sinceDateTime cannot be a future date."));
+            });
         }
 
         #endregion ScsProductDataSinceDateTime
-
     }
 }

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Storage/ExchangeSetStorageProviderTests.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Storage/ExchangeSetStorageProviderTests.cs
@@ -81,7 +81,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Storage
             string correlationId = "a6670458-9bbc-4b52-95a2-d1f50fe9e3ae";
             A.CallTo(() => fakeAzureBlobStorageService.StoreSaleCatalogueServiceResponseAsync(A<string>.Ignored, A<string>.Ignored, A<SalesCatalogueProductResponse>.Ignored, A<string>.Ignored, A<string>.Ignored, A<string>.Ignored, cancellationToken, A<string>.Ignored, fakeScsRequestDateTime, A<bool>.Ignored, A<bool>.Ignored, A<ExchangeSetResponse>.Ignored)).Returns(true);
             isSCSResponseAdded = await service.SaveSalesCatalogueStorageDetails(salesCatalogueResponse, batchId, callBackUri, exchangeSetStandard.ToString(), correlationId, fakeExpiryDate, fakeScsRequestDateTime, fakeIsEmptyEncExchangeSet, fakeIsEmptyAioExchangeSet, exchangeSetResponse);
-            Assert.That(true, Is.EqualTo(isSCSResponseAdded));
+            Assert.That(isSCSResponseAdded, Is.EqualTo(true));
         }
 
         [Test]
@@ -98,7 +98,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Storage
             CancellationToken cancellationToken = CancellationToken.None;
             A.CallTo(() => fakeAzureBlobStorageService.StoreSaleCatalogueServiceResponseAsync(A<string>.Ignored, A<string>.Ignored, A<SalesCatalogueProductResponse>.Ignored, A<string>.Ignored, A<string>.Ignored, A<string>.Ignored, cancellationToken, A<string>.Ignored, fakeScsRequestDateTime, A<bool>.Ignored, A<bool>.Ignored, A<ExchangeSetResponse>.Ignored)).Returns(false);
             bool isSCSResponseAdded = await service.SaveSalesCatalogueStorageDetails(salesCatalogueResponse, batchId, callBackUri, exchangeSetStandard.ToString(), correlationId, fakeExpiryDate, fakeScsRequestDateTime, fakeIsEmptyEncExchangeSet, fakeIsEmptyAioExchangeSet, exchangeSetResponse);
-            Assert.That(false, Is.EqualTo(isSCSResponseAdded));
+            Assert.That(isSCSResponseAdded, Is.EqualTo(false));
         }
     }
 }

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/UKHO.ExchangeSetService.API.UnitTests.csproj
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/UKHO.ExchangeSetService.API.UnitTests.csproj
@@ -20,6 +20,10 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.56.0.67649">

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Validation/ProductIdentifiersValidatorTests.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Validation/ProductIdentifiersValidatorTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
+using System.Linq;
 using FluentValidation.TestHelper;
 using NUnit.Framework;
-using System.Linq;
 using UKHO.ExchangeSetService.API.Validation;
 using UKHO.ExchangeSetService.Common.Models.Request;
 
@@ -112,7 +112,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Validation
                 CallbackUri = callbackUri
             };
             var result = validator.TestValidate(model);
-            Assert.That(0, Is.EqualTo(result.Errors.Count));
+            Assert.That(result.Errors, Is.Empty);
         }
         #endregion
     }

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Validation/ScsProductIdentifiersValidatorTests.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Validation/ScsProductIdentifiersValidatorTests.cs
@@ -1,6 +1,6 @@
-﻿using NUnit.Framework;
-using System.Linq;
+﻿using System.Linq;
 using FluentValidation.TestHelper;
+using NUnit.Framework;
 using UKHO.ExchangeSetService.API.Validation;
 using UKHO.ExchangeSetService.Common.Models.Request;
 
@@ -54,7 +54,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Validation
                 ProductIdentifier = productIdentifiers,
             };
             var result = validator.TestValidate(model);
-            Assert.That(0, Is.EqualTo(result.Errors.Count));
+            Assert.That(result.Errors, Is.Empty);
         }
         #endregion
     }

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.csproj
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="8.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.11" />
     <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="8.0.11" />
-    <PackageReference Include="Microsoft.Graph.Core" Version="3.2.1" />
+    <PackageReference Include="Microsoft.Graph.Core" Version="3.2.2" />
     <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="3.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common.UnitTests/UKHO.ExchangeSetService.Common.UnitTests.csproj
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common.UnitTests/UKHO.ExchangeSetService.Common.UnitTests.csproj
@@ -15,7 +15,7 @@
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.5.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.CleanUpJob.UnitTests/UKHO.ExchangeSetService.Webjob.CleanUpJob.UnitTests.csproj
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.CleanUpJob.UnitTests/UKHO.ExchangeSetService.Webjob.CleanUpJob.UnitTests.csproj
@@ -15,7 +15,7 @@
 		</PackageReference>
 		<PackageReference Include="FakeItEasy" Version="8.3.0" />
 		<PackageReference Include="NUnit" Version="4.3.2" />
-		<PackageReference Include="NUnit.Analyzers" Version="4.5.0">
+		<PackageReference Include="NUnit.Analyzers" Version="4.6.0">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/UKHO.ExchangeSetService.Webjob.UnitTests.csproj
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/UKHO.ExchangeSetService.Webjob.UnitTests.csproj
@@ -15,7 +15,7 @@
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.5.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
#### PR Classification
Code cleanup and package updates to improve test readability, maintainability, and consistency.

#### PR Summary
This pull request focuses on enhancing the structure and readability of unit tests, along with updating several package versions.
- Updated `Microsoft.Identity.Client` to `4.67.1` and added `NUnit.Analyzers` in `UKHO.ExchangeSetService.API.FunctionalTests.csproj`.
- Refactored `Assert.Multiple` and reordered `using` directives in `EssWebhookControllerTests.cs`, `ProductDataControllerTests.cs`, and `ProductInformationControllerTests.cs`.
- Reversed argument order in `Assert.That` statements in `ExchangeSetStorageProviderTests.cs`.
- Updated `NUnit.Analyzers` to `4.6.0` in multiple unit test project files.
- Refactored `Assert.That` statements to use `Is.Empty` in `ProductIdentifiersValidatorTests.cs` and `ScsProductIdentifiersValidatorTests.cs`.
