### PR TITLE
Remove FluentAssertions

### DIFF
--- a/Deployment/templates/app-deploy.yml
+++ b/Deployment/templates/app-deploy.yml
@@ -138,7 +138,7 @@ jobs:
             displayName: 'Use .NET SDK'
             inputs:
               packageType: sdk
-              version: 6.0.x
+              version: $(SdkVersion)
 
           - task: DotNetCoreCLI@2
             displayName: "Run Functional"

--- a/Deployment/templates/build-test-publish.yml
+++ b/Deployment/templates/build-test-publish.yml
@@ -4,10 +4,6 @@ parameters:
   type: boolean
   default: false
 
-- name: DotNetVersion
-  type: string
-  default: '6.0.x'
-
 jobs:
 - job: Dependencychecker
   condition: eq('${{ parameters.DisableDependencyCheck }}', false)

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/UKHO.ExchangeSetService.API.FunctionalTests.csproj
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/UKHO.ExchangeSetService.API.FunctionalTests.csproj
@@ -11,14 +11,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Data.Tables" Version="12.9.1" />
+    <PackageReference Include="Azure.Data.Tables" Version="12.10.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
     <PackageReference Include="JWT" Version="11.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.67.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.67.2" />
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
@@ -30,7 +30,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Text.Json" Version="9.0.0" />
+    <PackageReference Include="System.Text.Json" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/UKHO.ExchangeSetService.API.FunctionalTests.csproj
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/UKHO.ExchangeSetService.API.FunctionalTests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.67.2" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.67.1" />
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/UKHO.ExchangeSetService.API.FunctionalTests.csproj
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/UKHO.ExchangeSetService.API.FunctionalTests.csproj
@@ -13,7 +13,6 @@
   <ItemGroup>
     <PackageReference Include="Azure.Data.Tables" Version="12.9.1" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="JWT" Version="11.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Controllers/EssWebhookControllerTests.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Controllers/EssWebhookControllerTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using FakeItEasy;
-using FluentAssertions;
 using FluentValidation.Results;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -164,7 +163,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 
             var result = (OkObjectResult)await fakeWebHookController.NewFilesPublished(fakeCacheJson);
 
-            result.StatusCode.Should().Be(200);
+            Assert.That(result.StatusCode, Is.EqualTo(200));
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
               && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -197,7 +196,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 
             var result = (OkObjectResult)await fakeWebHookController.NewFilesPublished(fakeCacheJson);
 
-            result.StatusCode.Should().Be(200);
+            Assert.That(result.StatusCode, Is.EqualTo(200));
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
               && call.GetArgument<LogLevel>(0) == LogLevel.Information

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Controllers/ProductDataControllerTests.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Controllers/ProductDataControllerTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using FakeItEasy;
-using FluentAssertions;
 using FluentValidation.Results;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -27,7 +26,6 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
         private IHttpContextAccessor fakeHttpContextAccessor;
         private IProductDataService fakeProductDataService;
         private ILogger<ProductDataController> fakeLogger;
-        public const string errorMessage = "Either body is null or malformed";
 
         [SetUp]
         public void Setup()
@@ -262,8 +260,8 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
             A.CallTo(() => fakeProductDataService.ValidateProductDataByProductIdentifiers(A<ProductIdentifierRequest>.Ignored))
                  .Returns(new ValidationResult(new List<ValidationFailure>()));
 
-            string[] productIdentifiers = new string[] { "GB123456", "GB160060", "AU334550" };
-            string callbackUri = string.Empty;
+            var productIdentifiers = new string[] { "GB123456", "GB160060", "AU334550" };
+            var callbackUri = string.Empty;
 
             A.CallTo(() => fakeProductDataService.CreateProductDataByProductIdentifiers(A<ProductIdentifierRequest>.Ignored, A<AzureAdB2C>.Ignored))
                  .Returns(exchangeSetServiceResponse);
@@ -271,8 +269,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
             var result = (BadRequestObjectResult)await controller.PostProductIdentifiers(productIdentifiers, callbackUri, ExchangeSetStandard.s57.ToString());
             var errors = (ErrorDescription)result.Value;
 
-            result.StatusCode.Should().Be(400);
-            errors.Errors.Single().Description.Should().Be("The Exchange Set requested is very large and will not be created, please use a standard Exchange Set provided by the UKHO.");
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.StatusCode, Is.EqualTo(400));
+                Assert.That(errors.Errors.Single().Description, Is.EqualTo("The Exchange Set requested is very large and will not be created, please use a standard Exchange Set provided by the UKHO."));
+            });
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Error
@@ -294,16 +295,19 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
             A.CallTo(() => fakeProductDataService.ValidateProductDataByProductIdentifiers(A<ProductIdentifierRequest>.Ignored))
                  .Returns(new ValidationResult(new List<ValidationFailure>()));
 
-            string[] productIdentifiers = new string[] { "GB123456", "GB160060", "AU334550" };
-            string callbackUri = string.Empty;
+            var productIdentifiers = new string[] { "GB123456", "GB160060", "AU334550" };
+            var callbackUri = string.Empty;
 
             A.CallTo(() => fakeProductDataService.CreateProductDataByProductIdentifiers(A<ProductIdentifierRequest>.Ignored, A<AzureAdB2C>.Ignored))
                  .Returns(exchangeSetServiceResponse);
 
             var result = (OkObjectResult)await controller.PostProductIdentifiers(productIdentifiers, callbackUri, ExchangeSetStandard.s63.ToString());
 
-            result.StatusCode.Should().Be(200);
-            ((UKHO.ExchangeSetService.Common.Models.Response.ExchangeSetResponse)result.Value).ExchangeSetCellCount.Should().Be(exchangeSetServiceResponse.ExchangeSetResponse.ExchangeSetCellCount);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.StatusCode, Is.EqualTo(200));
+                Assert.That(((ExchangeSetResponse)result.Value).ExchangeSetCellCount, Is.EqualTo(exchangeSetServiceResponse.ExchangeSetResponse.ExchangeSetCellCount));
+            });
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -498,8 +502,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
                             { new() { ProductName = "demo" } }, "", ExchangeSetStandard.s57.ToString());
             var errors = (ErrorDescription)result.Value;
 
-            result.StatusCode.Should().Be(400);
-            errors.Errors.Single().Description.Should().Be("The Exchange Set requested is very large and will not be created, please use a standard Exchange Set provided by the UKHO.");
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.StatusCode, Is.EqualTo(400));
+                Assert.That(errors.Errors.Single().Description, Is.EqualTo("The Exchange Set requested is very large and will not be created, please use a standard Exchange Set provided by the UKHO."));
+            });
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Error
@@ -527,8 +534,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
             var result = (OkObjectResult)await controller.PostProductDataByProductVersions(new List<ProductVersionRequest>()
                             { new() { ProductName = "demo" } }, "", ExchangeSetStandard.s63.ToString());
 
-            result.StatusCode.Should().Be(200);
-            ((UKHO.ExchangeSetService.Common.Models.Response.ExchangeSetResponse)result.Value).ExchangeSetCellCount.Should().Be(exchangeSetServiceResponse.ExchangeSetResponse.ExchangeSetCellCount);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.StatusCode, Is.EqualTo(200));
+                Assert.That(((ExchangeSetResponse)result.Value).ExchangeSetCellCount, Is.EqualTo(exchangeSetServiceResponse.ExchangeSetResponse.ExchangeSetCellCount));
+            });
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -682,8 +692,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
             var result = (BadRequestObjectResult)await controller.GetProductDataSinceDateTime("Wed, 21 Oct 2015 07:28:00 GMT", "https://www.abc.com", ExchangeSetStandard.s57.ToString());
             var errors = (ErrorDescription)result.Value;
 
-            result.StatusCode.Should().Be(400);
-            errors.Errors.Single().Description.Should().Be("The Exchange Set requested is very large and will not be created, please use a standard Exchange Set provided by the UKHO.");
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.StatusCode, Is.EqualTo(400));
+                Assert.That(errors.Errors.Single().Description, Is.EqualTo("The Exchange Set requested is very large and will not be created, please use a standard Exchange Set provided by the UKHO."));
+            });
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Error
@@ -710,8 +723,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 
             var result = (OkObjectResult)await controller.GetProductDataSinceDateTime("Wed, 21 Oct 2015 07:28:00 GMT", "https://www.abc.com", ExchangeSetStandard.s63.ToString());
 
-            result.StatusCode.Should().Be(200);
-            ((UKHO.ExchangeSetService.Common.Models.Response.ExchangeSetResponse)result.Value).ExchangeSetCellCount.Should().Be(exchangeSetServiceResponse.ExchangeSetResponse.ExchangeSetCellCount);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.StatusCode, Is.EqualTo(200));
+                Assert.That(((ExchangeSetResponse)result.Value).ExchangeSetCellCount, Is.EqualTo(exchangeSetServiceResponse.ExchangeSetResponse.ExchangeSetCellCount));
+            });
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Filters/BespokeExchangeSetAuthorizationFilterAttributeTests.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Filters/BespokeExchangeSetAuthorizationFilterAttributeTests.cs
@@ -1,5 +1,9 @@
-﻿using FakeItEasy;
-using FluentAssertions;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using FakeItEasy;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
@@ -10,11 +14,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Security.Claims;
-using System.Threading.Tasks;
 using UKHO.ExchangeSetService.API.Filters;
 using UKHO.ExchangeSetService.Common.Configuration;
 using UKHO.ExchangeSetService.Common.Helpers;
@@ -70,9 +69,8 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Filters
         [Test]
         public void WhenParameterIsNull_ThenConstructorThrowsArgumentNullException()
         {
-            Action nullBespokeFilterAttribute = () => new BespokeExchangeSetAuthorizationFilterAttribute(null, null, null, null);
-
-            nullBespokeFilterAttribute.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("azureAdConfiguration");
+            var ex = Assert.Throws<ArgumentNullException>(() => new BespokeExchangeSetAuthorizationFilterAttribute(null, null, null, null));
+            Assert.That(ex.ParamName, Is.EqualTo("azureAdConfiguration"));
         }
 
         [Test]
@@ -88,8 +86,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Filters
 
             await bespokeFilterAttribute.OnActionExecutionAsync(actionExecutingContext, () => Task.FromResult(actionExecutedContext));
 
-            httpContext.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
-            actionExecutingContext.ActionArguments[ExchangeSetStandard].Should().Be(Common.Models.Enums.ExchangeSetStandardForUnitTests.s63.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(httpContext.Response.StatusCode, Is.EqualTo(StatusCodes.Status200OK));
+                Assert.That(actionExecutingContext.ActionArguments[ExchangeSetStandard], Is.EqualTo(Common.Models.Enums.ExchangeSetStandardForUnitTests.s63.ToString()));
+            });
         }
 
         [Test]
@@ -107,8 +108,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Filters
 
             await bespokeFilterAttribute.OnActionExecutionAsync(actionExecutingContext, () => Task.FromResult(actionExecutedContext));
 
-            httpContext.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
-            actionExecutingContext.ActionArguments[ExchangeSetStandard].Should().Be(Common.Models.Enums.ExchangeSetStandardForUnitTests.s57.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(httpContext.Response.StatusCode, Is.EqualTo(StatusCodes.Status200OK));
+                Assert.That(actionExecutingContext.ActionArguments[ExchangeSetStandard], Is.EqualTo(Common.Models.Enums.ExchangeSetStandardForUnitTests.s57.ToString()));
+            });
         }
 
         [Test]
@@ -126,8 +130,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Filters
 
             await bespokeFilterAttribute.OnActionExecutionAsync(actionExecutingContext, () => Task.FromResult(actionExecutedContext));
 
-            httpContext.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
-            actionExecutingContext.ActionArguments[ExchangeSetStandard].Should().Be(Common.Models.Enums.ExchangeSetStandardForUnitTests.s63.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(httpContext.Response.StatusCode, Is.EqualTo(StatusCodes.Status200OK));
+                Assert.That(actionExecutingContext.ActionArguments[ExchangeSetStandard], Is.EqualTo(Common.Models.Enums.ExchangeSetStandardForUnitTests.s63.ToString()));
+            });
         }
 
         [Test]
@@ -146,8 +153,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Filters
 
             await bespokeFilterAttribute.OnActionExecutionAsync(actionExecutingContext, () => Task.FromResult(actionExecutedContext));
 
-            httpContext.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
-            actionExecutingContext.ActionArguments[ExchangeSetStandard].Should().Be(Common.Models.Enums.ExchangeSetStandardForUnitTests.s57.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(httpContext.Response.StatusCode, Is.EqualTo(StatusCodes.Status200OK));
+                Assert.That(actionExecutingContext.ActionArguments[ExchangeSetStandard], Is.EqualTo(Common.Models.Enums.ExchangeSetStandardForUnitTests.s57.ToString()));
+            });
         }
 
         [Test]
@@ -165,7 +175,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Filters
 
             await bespokeFilterAttribute.OnActionExecutionAsync(actionExecutingContext, () => Task.FromResult(actionExecutedContext));
 
-            httpContext.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+            Assert.That(httpContext.Response.StatusCode, Is.EqualTo(StatusCodes.Status400BadRequest));
         }
 
         [Test]
@@ -183,7 +193,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Filters
 
             await bespokeFilterAttribute.OnActionExecutionAsync(actionExecutingContext, () => Task.FromResult(actionExecutedContext));
 
-            httpContext.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+            Assert.That(httpContext.Response.StatusCode, Is.EqualTo(StatusCodes.Status400BadRequest));
         }
 
         [Test]
@@ -201,7 +211,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Filters
 
             await bespokeFilterAttribute.OnActionExecutionAsync(actionExecutingContext, () => Task.FromResult(actionExecutedContext));
 
-            httpContext.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+            Assert.That(httpContext.Response.StatusCode, Is.EqualTo(StatusCodes.Status400BadRequest));
         }
 
         [Test]
@@ -229,8 +239,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Filters
 
             await bespokeFilterAttribute.OnActionExecutionAsync(actionExecutingContext, () => Task.FromResult(actionExecutedContext));
 
-            httpContext.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
-            actionExecutingContext.ActionArguments[ExchangeSetStandard].Should().Be(Common.Models.Enums.ExchangeSetStandardForUnitTests.s57.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(httpContext.Response.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+                Assert.That(actionExecutingContext.ActionArguments[ExchangeSetStandard], Is.EqualTo(Common.Models.Enums.ExchangeSetStandardForUnitTests.s57.ToString()));
+            });
         }
 
         [Test]
@@ -250,7 +263,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Filters
 
             await bespokeFilterAttribute.OnActionExecutionAsync(actionExecutingContext, () => Task.FromResult(actionExecutedContext));
 
-            httpContext.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+            Assert.That(httpContext.Response.StatusCode, Is.EqualTo(StatusCodes.Status400BadRequest));
         }
 
         [Test]
@@ -277,8 +290,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Filters
             A.CallTo(() => fakeAzureAdB2CHelper.IsAzureB2CUser(A<AzureAdB2C>.Ignored, A<string>.Ignored)).Returns(true);
             await bespokeFilterAttribute.OnActionExecutionAsync(actionExecutingContext, () => Task.FromResult(actionExecutedContext));
 
-            httpContext.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
-            actionExecutingContext.ActionArguments[ExchangeSetStandard].Should().Be(Common.Models.Enums.ExchangeSetStandardForUnitTests.s57.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(httpContext.Response.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+                Assert.That(actionExecutingContext.ActionArguments[ExchangeSetStandard], Is.EqualTo(Common.Models.Enums.ExchangeSetStandardForUnitTests.s57.ToString()));
+            });
         }
 
         [Test]
@@ -305,8 +321,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Filters
             A.CallTo(() => fakeAzureAdB2CHelper.IsAzureB2CUser(A<AzureAdB2C>.Ignored, A<string>.Ignored)).Returns(true);
             await bespokeFilterAttribute.OnActionExecutionAsync(actionExecutingContext, () => Task.FromResult(actionExecutedContext));
 
-            httpContext.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
-            actionExecutingContext.ActionArguments[ExchangeSetStandard].Should().Be(Common.Models.Enums.ExchangeSetStandardForUnitTests.s57.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(httpContext.Response.StatusCode, Is.EqualTo(StatusCodes.Status200OK));
+                Assert.That(actionExecutingContext.ActionArguments[ExchangeSetStandard], Is.EqualTo(Common.Models.Enums.ExchangeSetStandardForUnitTests.s57.ToString()));
+            });
         }
 
         [Test]
@@ -333,8 +352,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Filters
             A.CallTo(() => fakeAzureAdB2CHelper.IsAzureB2CUser(A<AzureAdB2C>.Ignored, A<string>.Ignored)).Returns(true);
             await bespokeFilterAttribute.OnActionExecutionAsync(actionExecutingContext, () => Task.FromResult(actionExecutedContext));
 
-            httpContext.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
-            actionExecutingContext.ActionArguments[ExchangeSetStandard].Should().Be(Common.Models.Enums.ExchangeSetStandardForUnitTests.s57.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(httpContext.Response.StatusCode, Is.EqualTo(StatusCodes.Status200OK));
+                Assert.That(actionExecutingContext.ActionArguments[ExchangeSetStandard], Is.EqualTo(Common.Models.Enums.ExchangeSetStandardForUnitTests.s57.ToString()));
+            });
         }
 
         [Test]
@@ -364,8 +386,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Filters
             A.CallTo(() => fakeAzureAdB2CHelper.IsAzureB2CUser(A<AzureAdB2C>.Ignored, A<string>.Ignored)).Returns(true);
             await bespokeFilterAttribute.OnActionExecutionAsync(actionExecutingContext, () => Task.FromResult(actionExecutedContext));
 
-            httpContext.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
-            actionExecutingContext.ActionArguments[ExchangeSetStandard].Should().Be(Common.Models.Enums.ExchangeSetStandardForUnitTests.s57.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(httpContext.Response.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+                Assert.That(actionExecutingContext.ActionArguments[ExchangeSetStandard], Is.EqualTo(Common.Models.Enums.ExchangeSetStandardForUnitTests.s57.ToString()));
+            });
         }
 
         [Test]
@@ -391,8 +416,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Filters
             A.CallTo(() => fakeAzureAdB2CHelper.IsAzureB2CUser(A<AzureAdB2C>.Ignored, A<string>.Ignored)).Returns(true);
             await bespokeFilterAttribute.OnActionExecutionAsync(actionExecutingContext, () => Task.FromResult(actionExecutedContext));
 
-            httpContext.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
-            actionExecutingContext.ActionArguments[ExchangeSetStandard].Should().Be(Common.Models.Enums.ExchangeSetStandardForUnitTests.s57.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(httpContext.Response.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+                Assert.That(actionExecutingContext.ActionArguments[ExchangeSetStandard], Is.EqualTo(Common.Models.Enums.ExchangeSetStandardForUnitTests.s57.ToString()));
+            });
         }
 
         [Test]
@@ -422,8 +450,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Filters
             A.CallTo(() => fakeAzureAdB2CHelper.IsAzureB2CUser(A<AzureAdB2C>.Ignored, A<string>.Ignored)).Returns(true);
             await bespokeFilterAttribute.OnActionExecutionAsync(actionExecutingContext, () => Task.FromResult(actionExecutedContext));
 
-            httpContext.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
-            actionExecutingContext.ActionArguments[ExchangeSetStandard].Should().Be(Common.Models.Enums.ExchangeSetStandardForUnitTests.s57.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(httpContext.Response.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+                Assert.That(actionExecutingContext.ActionArguments[ExchangeSetStandard], Is.EqualTo(Common.Models.Enums.ExchangeSetStandardForUnitTests.s57.ToString()));
+            });
 
             A.CallTo(fakelogger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Error

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Services/ProductDataServiceTests.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Services/ProductDataServiceTests.cs
@@ -5,7 +5,6 @@ using System.Net;
 using System.Threading.Tasks;
 using AutoMapper;
 using FakeItEasy;
-using FluentAssertions;
 using FluentValidation.Results;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -810,8 +809,8 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                     ExchangeSetStandard = ExchangeSetStandard.s57.ToString()
                 }, GetAzureADToken());
 
-            result.Should().BeOfType<ExchangeSetServiceResponse>();
-            result.HttpStatusCode.Should().Be(HttpStatusCode.BadRequest);
+            Assert.That(result, Is.TypeOf<ExchangeSetServiceResponse>());
+            Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
         }
 
         [Test]
@@ -847,8 +846,8 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                 }, GetAzureADToken());
 
 
-            result.Should().BeOfType<ExchangeSetServiceResponse>();
-            result.HttpStatusCode.Should().Be(HttpStatusCode.Created);
+            Assert.That(result, Is.TypeOf<ExchangeSetServiceResponse>());
+            Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.Created));
 
             A.CallTo(logger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -1290,8 +1289,8 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                 ExchangeSetStandard = ExchangeSetStandard.s57.ToString()
             }, GetAzureADToken());
 
-            result.Should().BeOfType<ExchangeSetServiceResponse>();
-            result.HttpStatusCode.Should().Be(HttpStatusCode.BadRequest);
+            Assert.That(result, Is.TypeOf<ExchangeSetServiceResponse>());
+            Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
         }
 
         [Test]
@@ -1328,8 +1327,8 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
             }, GetAzureADToken());
 
 
-            result.Should().BeOfType<ExchangeSetServiceResponse>();
-            result.HttpStatusCode.Should().Be(HttpStatusCode.Created);
+            Assert.That(result, Is.TypeOf<ExchangeSetServiceResponse>());
+            Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.Created));
 
 
             A.CallTo(logger).Where(call => call.Method.Name == "Log"
@@ -1607,8 +1606,8 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                 CallbackUri = string.Empty
             }, GetAzureADToken());
 
-            result.Should().BeOfType<ExchangeSetServiceResponse>();
-            result.HttpStatusCode.Should().Be(HttpStatusCode.Created);
+            Assert.That(result, Is.TypeOf<ExchangeSetServiceResponse>());
+            Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.Created));
 
             A.CallTo(logger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -1876,8 +1875,8 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                 CallbackUri = string.Empty
             }, GetAzureADToken());
 
-            result.Should().BeOfType<ExchangeSetServiceResponse>();
-            result.HttpStatusCode.Should().Be(HttpStatusCode.BadRequest);
+            Assert.That(result, Is.TypeOf<ExchangeSetServiceResponse>());
+            Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
         }
 
         [Test]
@@ -1904,8 +1903,8 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                 CallbackUri = string.Empty
             }, GetAzureADToken());
 
-            result.Should().BeOfType<ExchangeSetServiceResponse>();
-            result.HttpStatusCode.Should().Be(HttpStatusCode.Created);
+            Assert.That(result, Is.TypeOf<ExchangeSetServiceResponse>());
+            Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.Created));
 
             A.CallTo(logger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/UKHO.ExchangeSetService.API.UnitTests.csproj
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/UKHO.ExchangeSetService.API.UnitTests.csproj
@@ -17,7 +17,7 @@
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/UKHO.ExchangeSetService.API.UnitTests.csproj
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/UKHO.ExchangeSetService.API.UnitTests.csproj
@@ -16,7 +16,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.csproj
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="8.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="7.2.0" />
-    <PackageReference Include="System.Text.Json" Version="9.0.0" />
+    <PackageReference Include="System.Text.Json" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/UKHO.ExchangeSetService.Common.csproj
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/UKHO.ExchangeSetService.Common.csproj
@@ -12,7 +12,7 @@
 
    <ItemGroup>
     <PackageReference Include="Azure.Data.Tables" Version="12.10.0" />
-    <PackageReference Include="Azure.Identity" Version="1.13.2" />
+    <PackageReference Include="Azure.Identity" Version="1.13.1" />
     <PackageReference Include="Azure.Storage.Common" Version="12.22.0" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.21.0" />
     <PackageReference Include="CsvHelper" Version="33.0.1" />

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/UKHO.ExchangeSetService.Common.csproj
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/UKHO.ExchangeSetService.Common.csproj
@@ -11,21 +11,21 @@
   </PropertyGroup>
 
    <ItemGroup>
-    <PackageReference Include="Azure.Data.Tables" Version="12.9.1" />
-    <PackageReference Include="Azure.Identity" Version="1.13.1" />
+    <PackageReference Include="Azure.Data.Tables" Version="12.10.0" />
+    <PackageReference Include="Azure.Identity" Version="1.13.2" />
     <PackageReference Include="Azure.Storage.Common" Version="12.22.0" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.21.0" />
     <PackageReference Include="CsvHelper" Version="33.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.22.0" />
     <PackageReference Include="Microsoft.IdentityModel.Logging" Version="8.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="7.2.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
     <PackageReference Include="System.IO.Abstractions" Version="21.2.1" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="9.0.0" />
-    <PackageReference Include="System.Text.Json" Version="9.0.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="9.0.1" />
+    <PackageReference Include="System.Text.Json" Version="9.0.1" />
     <PackageReference Include="UKHO.Logging.EventHubLogProvider" Version="1.24163.8" />
   </ItemGroup>
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -114,7 +114,6 @@ stages:
     - template: Deployment/templates/build-test-publish.yml  
       parameters:
         DisableDependencyCheck: ${{ parameters.DisableDependencyCheck }}
-        DotNetVersion: '8.0.x'
  
   - stage: Devdeploy
     dependsOn:


### PR DESCRIPTION
#### PR Classification
Code cleanup and dependency updates.

#### PR Summary
This pull request focuses on removing the `FluentAssertions` package, replacing its assertions with `NUnit` assertions, and updating several package versions.
- `EssWebhookControllerTests.cs` and `ProductDataControllerTests.cs`: Replaced `FluentAssertions` with `NUnit` assertions.
- `UKHO.ExchangeSetService.API.FunctionalTests.csproj`: Updated multiple package versions and removed `FluentAssertions`.
- `UKHO.ExchangeSetService.Common.csproj`: Updated versions of `Azure.Data.Tables`, `Azure.Identity`, `Microsoft.Extensions.Http.Polly`, `System.Text.Encoding.CodePages`, and `System.Text.Json`.
- `UKHO.ExchangeSetService.API.UnitTests.csproj`: Removed `FluentAssertions` and updated `Microsoft.AspNetCore.Http.Abstractions` package version.
