### PR TITLE
TLS-Update

### DIFF
--- a/Deployment/src/Modules/CacheStorage/main.tf
+++ b/Deployment/src/Modules/CacheStorage/main.tf
@@ -5,6 +5,7 @@ resource "azurerm_storage_account" "ess_cache_storage" {
   account_tier = "Standard"
   account_replication_type = "LRS"
   account_kind = "StorageV2"
+  min_tls_version = "TLS1_2"
   allow_nested_items_to_be_public  = false
   network_rules {
     default_action             = "Deny"

--- a/Deployment/src/Modules/EventHub/main.tf
+++ b/Deployment/src/Modules/EventHub/main.tf
@@ -5,6 +5,7 @@ resource "azurerm_eventhub_namespace" "eventhub_namespace" {
   sku                 = "Standard"
   capacity            = 1
   tags                = var.tags
+  minimum_tls_version = "1.2"
 }
 
 resource "azurerm_eventhub" "eventhub" {

--- a/Deployment/src/Modules/EventHub/main.tf
+++ b/Deployment/src/Modules/EventHub/main.tf
@@ -54,6 +54,7 @@ resource "azurerm_storage_account" "logstashStorage" {
   resource_group_name       = var.resource_group_name
   location                  = var.location
   account_kind              = "StorageV2"
+  min_tls_version           = "TLS1_2"
   account_tier              = "Standard"
   account_replication_type  = "LRS"
   access_tier               = "Hot"

--- a/Deployment/src/Modules/FulfilmentStorage/main.tf
+++ b/Deployment/src/Modules/FulfilmentStorage/main.tf
@@ -5,6 +5,7 @@ resource "azurerm_storage_account" "small_exchange_set_storage" {
   account_tier = "Standard"
   account_replication_type = "LRS"
   account_kind = "StorageV2"
+  min_tls_version = "TLS1_2"
   allow_nested_items_to_be_public  = false
   network_rules {
     default_action             = "Deny"
@@ -36,6 +37,7 @@ resource "azurerm_storage_account" "medium_exchange_set_storage" {
   account_tier = "Standard"
   account_replication_type = "LRS"
   account_kind = "StorageV2"
+  min_tls_version = "TLS1_2"
   allow_nested_items_to_be_public     = false
   network_rules {
     default_action             = "Deny"
@@ -67,6 +69,7 @@ resource "azurerm_storage_account" "large_exchange_set_storage" {
   account_tier = "Standard"
   account_replication_type = "LRS"
   account_kind = "StorageV2"
+  min_tls_version = "TLS1_2"
   allow_nested_items_to_be_public     = false
   network_rules {
     default_action             = "Deny"

--- a/MockApiDeployment/src/Modules/Storage/main.tf
+++ b/MockApiDeployment/src/Modules/Storage/main.tf
@@ -5,6 +5,7 @@ resource "azurerm_storage_account" "storage" {
   account_tier = "Standard"
   account_replication_type = "LRS"
   account_kind = "StorageV2"
+  min_tls_version = "TLS1_2"
   tags = var.tags
 }
 

--- a/NVDSuppressions.xml
+++ b/NVDSuppressions.xml
@@ -557,7 +557,11 @@
     <cve>CVE-2021-22134</cve>
     <cve>CVE-2020-7020</cve>
     <cve>CVE-2023-49921</cve>
+    <cve>CVE-2024-23444</cve>
+    <cve>CVE-2024-23450</cve>
+    <cve>CVE-2024-43709</cve>
   </suppress>
+  
   <suppress>
     <notes>
       <![CDATA[
@@ -617,4 +621,5 @@
     <packageUrl regex="true">^pkg:nuget/Azure\.Core@.*$</packageUrl>
     <cve>CVE-2024-43591</cve>
   </suppress>
+  
 </suppressions>

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/Helpers/AzureBlobStorageClient.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/Helpers/AzureBlobStorageClient.cs
@@ -14,10 +14,14 @@ namespace UKHO.ExchangeSetService.Common.Helpers
     {
         public async Task<BlobClient> GetBlobClient(string fileName, string storageAccountConnectionString, string containerName)
         {
+            BlobClient blobClient = null;
             var blobServiceClient = new BlobServiceClient(storageAccountConnectionString);
             var blobContainerClient = blobServiceClient.GetBlobContainerClient(containerName);
-            await blobContainerClient.CreateIfNotExistsAsync();
-            return blobContainerClient.GetBlobClient(fileName);
+            if (await blobContainerClient.ExistsAsync())
+            {
+                blobClient = blobContainerClient.GetBlobClient(fileName);
+            }
+            return blobClient;
         }
 
         public BlobClient GetBlobClientByUri(string uri, StorageSharedKeyCredential keyCredential)

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/Helpers/AzureBlobStorageClient.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/Helpers/AzureBlobStorageClient.cs
@@ -14,14 +14,10 @@ namespace UKHO.ExchangeSetService.Common.Helpers
     {
         public async Task<BlobClient> GetBlobClient(string fileName, string storageAccountConnectionString, string containerName)
         {
-            BlobClient blobClient = null;
             var blobServiceClient = new BlobServiceClient(storageAccountConnectionString);
             var blobContainerClient = blobServiceClient.GetBlobContainerClient(containerName);
-            if (await blobContainerClient.ExistsAsync())
-            {
-                blobClient = blobContainerClient.GetBlobClient(fileName);
-            }
-            return blobClient;
+            await blobContainerClient.CreateIfNotExistsAsync();
+            return blobContainerClient.GetBlobClient(fileName);
         }
 
         public BlobClient GetBlobClientByUri(string uri, StorageSharedKeyCredential keyCredential)


### PR DESCRIPTION
#### PR Classification
Security enhancements and vulnerability suppressions.

#### PR Summary
Enforced minimum TLS version 1.2 for Azure resources and added new CVE suppressions.
- Updated `azurerm_storage_account` resources to enforce `min_tls_version = "TLS1_2"` and `allow_nested_items_to_be_public = false`.
- Updated `azurerm_eventhub_namespace` resource to enforce `minimum_tls_version = "1.2"`.
- Added new CVE suppressions in `NVDSuppressions.xml` for `CVE-2024-23444`, `CVE-2024-23450`, `CVE-2024-43709`, and `CVE-2024-43591`.
- Added a new suppression block in `NVDSuppressions.xml` for `MongoDB.Bson.dll`.
