### PR TITLE
Update from main 04/03/2025

### DIFF
--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/UKHO.ExchangeSetService.API.FunctionalTests.csproj
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/UKHO.ExchangeSetService.API.FunctionalTests.csproj
@@ -14,11 +14,11 @@
     <PackageReference Include="Azure.Data.Tables" Version="12.10.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
     <PackageReference Include="JWT" Version="11.0.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.2" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.67.1" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.69.1" />
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/UKHO.ExchangeSetService.API.UnitTests.csproj
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/UKHO.ExchangeSetService.API.UnitTests.csproj
@@ -16,7 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.6.0">

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.csproj
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Elastic.Apm.NetCoreAll" Version="1.31.0" />
     <PackageReference Include="FluentValidation" Version="11.11.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.13" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="8.0.13" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.13" />
     <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="8.0.13" />
@@ -23,9 +23,9 @@
     <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="3.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="8.0.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="7.2.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="7.3.1" />
     <PackageReference Include="System.Text.Json" Version="9.0.2" />
   </ItemGroup>
 

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/UKHO.ExchangeSetService.Common.csproj
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common/UKHO.ExchangeSetService.Common.csproj
@@ -12,18 +12,18 @@
 
    <ItemGroup>
     <PackageReference Include="Azure.Data.Tables" Version="12.10.0" />
-    <PackageReference Include="Azure.Identity" Version="1.13.1" />
+    <PackageReference Include="Azure.Identity" Version="1.13.2" />
     <PackageReference Include="Azure.Storage.Common" Version="12.22.0" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.21.0" />
     <PackageReference Include="CsvHelper" Version="33.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.22.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Logging" Version="8.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.23.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Logging" Version="8.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="7.2.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="7.3.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.5.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="21.3.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.6.0" />
+    <PackageReference Include="System.IO.Abstractions" Version="22.0.11" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="9.0.2" />
     <PackageReference Include="System.Text.Json" Version="9.0.2" />
     <PackageReference Include="UKHO.Logging.EventHubLogProvider" Version="1.24163.8" />

--- a/UKHO.SalesCatalogueFileShareServicesMock.API/UKHO.SalesCatalogueFileShareServicesMock.API/UKHO.SalesCatalogueFileShareServicesMock.API.csproj
+++ b/UKHO.SalesCatalogueFileShareServicesMock.API/UKHO.SalesCatalogueFileShareServicesMock.API/UKHO.SalesCatalogueFileShareServicesMock.API.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="8.0.13" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="7.2.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="7.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
#### PR Classification
Version upgrades for several NuGet packages across multiple project files.

#### PR Summary
This pull request updates various NuGet package versions to their latest releases to ensure compatibility and access to new features. 
- `UKHO.ExchangeSetService.API.csproj`: Upgraded `Microsoft.ApplicationInsights` to `2.23.0` and `Swashbuckle.AspNetCore` to `7.3.1`.
- `UKHO.ExchangeSetService.Common.csproj`: Upgraded `Azure.Identity` to `1.13.2`, `Microsoft.Extensions.Logging.ApplicationInsights` to `2.23.0`, and `System.IO.Abstractions` to `22.0.11`.
- `UKHO.ExchangeSetService.API.FunctionalTests.csproj`: Upgraded `Microsoft.Identity.Client` to `4.69.1`.
