### PR TITLE
Migrate webapp resource in Terraform

### DIFF
--- a/Deployment/src/Modules/Webapp/main.tf
+++ b/Deployment/src/Modules/Webapp/main.tf
@@ -11,7 +11,7 @@ resource "azurerm_app_service" "webapp_service" {
   name                = var.name
   location            = var.location
   resource_group_name = var.resource_group_name
-  app_service_plan_id = azurerm_app_service_plan.app_service_plan.id
+  app_service_plan_id = azurerm_service_plan.app_service_plan.id
   tags                = var.tags
 
   site_config {

--- a/Deployment/src/Modules/Webapp/main.tf
+++ b/Deployment/src/Modules/Webapp/main.tf
@@ -1,13 +1,10 @@
-resource "azurerm_app_service_plan" "app_service_plan" {
-  name                = "${var.name}-asp"
-  location            = var.location
-  resource_group_name = var.resource_group_name
-  
-  sku {
-	tier = var.app_service_sku.tier
-	size = var.app_service_sku.size
-  }
-  tags                = var.tags
+resource "azurerm_service_plan" "app_service_plan" {
+  name                   = "${var.name}-asp"
+  location               = var.location
+  resource_group_name    = var.resource_group_name
+  sku_name               = var.app_service_sku.size
+  os_type                = "Windows"
+  tags                   = var.tags
 }
 
 resource "azurerm_app_service" "webapp_service" {
@@ -52,7 +49,6 @@ resource "azurerm_app_service_slot" "staging" {
   resource_group_name = azurerm_app_service.webapp_service.resource_group_name
   app_service_plan_id = azurerm_app_service.webapp_service.app_service_plan_id
   tags                = azurerm_app_service.webapp_service.tags
-  
 
   site_config {
     windows_fx_version  =   "DOTNETCORE|6.0"
@@ -81,7 +77,6 @@ resource "azurerm_app_service_slot" "staging" {
 
   https_only          = azurerm_app_service.webapp_service.https_only
 }
-
 
 resource "azurerm_app_service_virtual_network_swift_connection" "webapp_vnet_integration" {
   app_service_id = azurerm_app_service.webapp_service.id

--- a/Deployment/src/migration.tf
+++ b/Deployment/src/migration.tf
@@ -1,0 +1,17 @@
+# Used to migrate deprecated resources without having to destroy and recreate them.
+# This file can be removed once the migration is complete in all environments, but will do no harm if left.
+# See PBI #205137.
+
+# service plans
+removed {
+  from = module.webapp_service.azurerm_app_service_plan.app_service_plan
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = module.webapp_service.azurerm_service_plan.app_service_plan
+  id = "${azurerm_resource_group.rg.id}/providers/Microsoft.Web/serverFarms/${local.web_app_name}-asp"
+}

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.sln
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.sln
@@ -59,6 +59,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{677CA5FC-9AD
 	ProjectSection(SolutionItems) = preProject
 		..\Deployment\src\azure.tf = ..\Deployment\src\azure.tf
 		..\Deployment\src\main.tf = ..\Deployment\src\main.tf
+		..\Deployment\src\migration.tf = ..\Deployment\src\migration.tf
 		..\Deployment\src\outputs.tf = ..\Deployment\src\outputs.tf
 		..\Deployment\src\resource-group.tf = ..\Deployment\src\resource-group.tf
 		..\Deployment\src\variables.tf = ..\Deployment\src\variables.tf


### PR DESCRIPTION
#### PR Classification
Refactor to update deprecated Azure resource types.

#### PR Summary
This pull request updates the resource type from `azurerm_app_service_plan` to `azurerm_service_plan` in the Terraform configuration, ensuring compatibility with the latest Azure standards. It also introduces a migration strategy to transition existing resources without disruption.
- **main.tf**: Changed `azurerm_app_service_plan` to `azurerm_service_plan` and updated relevant attributes.
- **main.tf**: Updated `app_service_plan_id` references in `azurerm_app_service` and `azurerm_app_service_slot`.
- **migration.tf**: Added to facilitate migration from deprecated resources without destruction.
- **UKHO.ExchangeSetService.API.sln**: Included `migration.tf` in the project structure.
