### PR TITLE
Use connection string for app insights

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -37,7 +37,7 @@ dotnet_style_namespace_match_folder = true:suggestion
 dotnet_style_readonly_field = true:suggestion
 
 # JSON files
-[*.json}]
+[*.json]
 insert_final_newline = true
 indent_style = space
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -34,9 +34,10 @@ dotnet_style_prefer_compound_assignment = true:suggestion
 dotnet_style_prefer_simplified_interpolation = true:suggestion
 dotnet_style_prefer_collection_expression = when_types_exactly_match:suggestion
 dotnet_style_namespace_match_folder = true:suggestion
+dotnet_style_readonly_field = true:suggestion
 
 # JSON files
-[*.json]
+[*.json}]
 insert_final_newline = true
 indent_style = space
 indent_size = 2

--- a/Deployment/src/Modules/AppInsights/outputs.tf
+++ b/Deployment/src/Modules/AppInsights/outputs.tf
@@ -1,4 +1,3 @@
-
-output "instrumentation_key" {
-  value = azurerm_application_insights.app_insights.instrumentation_key
+output "connection_string" {
+  value = azurerm_application_insights.app_insights.connection_string
 }

--- a/Deployment/src/main.tf
+++ b/Deployment/src/main.tf
@@ -68,7 +68,7 @@ module "webapp_service" {
     "EventHubLoggingConfiguration:Environment"             = local.env_name
     "EventHubLoggingConfiguration:MinimumLoggingLevel"     = "Warning"
     "EventHubLoggingConfiguration:UkhoMinimumLoggingLevel" = "Information"
-    "APPINSIGHTS_INSTRUMENTATIONKEY"                       = module.app_insights.instrumentation_key
+    "APPLICATIONINSIGHTS_CONNECTION_STRING"                = module.app_insights.connection_string
     "ASPNETCORE_ENVIRONMENT"                               = local.env_name
     "WEBSITE_RUN_FROM_PACKAGE"                             = "1"
     "WEBSITE_ENABLE_SYNC_UPDATE_SITE"                      = "true"
@@ -101,7 +101,7 @@ module "fulfilment_webapp" {
     "EventHubLoggingConfiguration:Environment"             = local.env_name
     "EventHubLoggingConfiguration:MinimumLoggingLevel"     = "Warning"
     "EventHubLoggingConfiguration:UkhoMinimumLoggingLevel" = "Information"
-    "APPINSIGHTS_INSTRUMENTATIONKEY"                       = module.app_insights.instrumentation_key
+    "APPLICATIONINSIGHTS_CONNECTION_STRING"                = module.app_insights.connection_string
     "ASPNETCORE_ENVIRONMENT"                               = local.env_name
     "WEBSITE_RUN_FROM_PACKAGE"                             = "1"
     "WEBSITE_ENABLE_SYNC_UPDATE_SITE"                      = "true"

--- a/MockApiDeployment/src/main.tf
+++ b/MockApiDeployment/src/main.tf
@@ -20,7 +20,7 @@ module "webapp_service" {
     "ASPNETCORE_ENVIRONMENT"                               = local.env_name
     "WEBSITE_RUN_FROM_PACKAGE"                             = "1"
     "WEBSITE_ENABLE_SYNC_UPDATE_SITE"                      = "true"
-    "APPINSIGHTS_INSTRUMENTATIONKEY"                       = "NOT_CONFIGURED"
+    "APPLICATIONINSIGHTS_CONNECTION_STRING"                = "NOT_CONFIGURED"
   }
   tags = local.tags
 

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API/appsettings.json
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API/appsettings.json
@@ -109,7 +109,7 @@
     "Environment": ""
   },
   "AllowedHosts": "*",
-  "APPINSIGHTS_INSTRUMENTATIONKEY": "",
+  "APPLICATIONINSIGHTS_CONNECTION_STRING": "",
   "MaximumNumerOfDaysValidForSinceDateTimeEndpoint": 28,
   "PrivilegedUserDomains": ""
 }

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.CleanUpJob/appsettings.json
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.CleanUpJob/appsettings.json
@@ -1,5 +1,5 @@
 {
-  "APPINSIGHTS_INSTRUMENTATIONKEY": "",
+  "APPLICATIONINSIGHTS_CONNECTION_STRING": "",
   "Logging": {
     "PathFormat": "Logs/UKHO.ESSCleanUp.WebJob-{Date}.txt",
     "Json": true,

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.CleanUpJob/appsettings.local.overrides.json
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.CleanUpJob/appsettings.local.overrides.json
@@ -1,5 +1,5 @@
 {
-  "APPINSIGHTS_INSTRUMENTATIONKEY": "",
+  "APPLICATIONINSIGHTS_CONNECTION_STRING": "",
   "Logging": {
     "PathFormat": "Logs/UKHO.ESSCleanUp.WebJob-{Date}.txt",
     "Json": true,

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.FulfilmentService/Program.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.FulfilmentService/Program.cs
@@ -1,37 +1,37 @@
-﻿using Microsoft.Azure.WebJobs.Host;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO.Abstractions;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Reflection;
+using Azure.Extensions.AspNetCore.Configuration.Secrets;
+using Azure.Identity;
+using Azure.Security.KeyVault.Secrets;
+using Elastic.Apm;
+using Elastic.Apm.Azure.Storage;
+using Elastic.Apm.DiagnosticSource;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using UKHO.Logging.EventHubLogProvider;
-#pragma warning disable S1128 // Unused "using" should be removed
+#if DEBUG
 using Serilog;
 using Serilog.Events;
-#pragma warning disable S1128 // Unused "using" should be removed
-using System;
-using System.Diagnostics.CodeAnalysis;
+#endif
 using UKHO.ExchangeSetService.Common.Configuration;
 using UKHO.ExchangeSetService.Common.Helpers;
-using UKHO.ExchangeSetService.Common.Storage;
-using UKHO.ExchangeSetService.FulfilmentService.Services;
-using System.Reflection;
-using System.Linq;
-using System.Net.Http.Headers;
-using System.IO.Abstractions;
-using Azure.Identity;
-using Azure.Security.KeyVault.Secrets;
-using Azure.Extensions.AspNetCore.Configuration.Secrets;
-using UKHO.ExchangeSetService.FulfilmentService.Configuration;
-using UKHO.ExchangeSetService.Common.Logging;
-using Microsoft.ApplicationInsights.Extensibility;
-using UKHO.ExchangeSetService.FulfilmentService.Filters;
-using UKHO.ExchangeSetService.FulfilmentService.Validation;
-using Elastic.Apm.Azure.Storage;
-using Elastic.Apm.DiagnosticSource;
-using Elastic.Apm;
 using UKHO.ExchangeSetService.Common.Helpers.Auth;
 using UKHO.ExchangeSetService.Common.Helpers.SalesCatalogue;
 using UKHO.ExchangeSetService.Common.Helpers.Zip;
+using UKHO.ExchangeSetService.Common.Logging;
+using UKHO.ExchangeSetService.Common.Storage;
+using UKHO.ExchangeSetService.FulfilmentService.Configuration;
+using UKHO.ExchangeSetService.FulfilmentService.Filters;
+using UKHO.ExchangeSetService.FulfilmentService.Services;
+using UKHO.ExchangeSetService.FulfilmentService.Validation;
+using UKHO.Logging.EventHubLogProvider;
 
 namespace UKHO.ExchangeSetService.FulfilmentService
 {
@@ -50,7 +50,7 @@ namespace UKHO.ExchangeSetService.FulfilmentService
 
             HostBuilder hostBuilder = BuildHostConfiguration();
             IHost host = hostBuilder.Build();
-            
+
             using (host)
             {
                 host.Run();
@@ -104,10 +104,11 @@ namespace UKHO.ExchangeSetService.FulfilmentService
                  builder.AddConsole();
 
                  //Add Application Insights if needed (if key exists in settings)
-                 string instrumentationKey = ConfigurationBuilder["APPINSIGHTS_INSTRUMENTATIONKEY"];
-                 if (!string.IsNullOrEmpty(instrumentationKey))
+                 var connectionString = ConfigurationBuilder["APPLICATIONINSIGHTS_CONNECTION_STRING"];
+
+                 if (!string.IsNullOrEmpty(connectionString))
                  {
-                     builder.AddApplicationInsightsWebJobs(o => o.InstrumentationKey = instrumentationKey);
+                     builder.AddApplicationInsightsWebJobs(o => o.ConnectionString = connectionString);
                  }
 
                  EventHubLoggingConfiguration eventhubConfig = ConfigurationBuilder.GetSection("EventHubLoggingConfiguration").Get<EventHubLoggingConfiguration>();

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.FulfilmentService/appsettings.json
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.FulfilmentService/appsettings.json
@@ -1,5 +1,5 @@
 {
-  "APPINSIGHTS_INSTRUMENTATIONKEY": "",
+  "APPLICATIONINSIGHTS_CONNECTION_STRING": "",
   "Logging": {
     "PathFormat": "Logs/UKHO.ESSFulfilmentService.WebJob-{Date}.txt",
     "Json": true,

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.FulfilmentService/appsettings.local.overrides.json
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.FulfilmentService/appsettings.local.overrides.json
@@ -1,5 +1,5 @@
 {
-  "APPINSIGHTS_INSTRUMENTATIONKEY": "",
+  "APPLICATIONINSIGHTS_CONNECTION_STRING": "",
   "Logging": {
     "PathFormat": "Logs/UKHO.ESSFulfilmentService.WebJob-{Date}.txt",
     "Json": true,


### PR DESCRIPTION
#### PR Classification
Configuration update for Application Insights integration.

#### PR Summary
This pull request updates the Application Insights configuration from using an instrumentation key to a connection string across multiple files, enhancing security and maintainability. 
- `appsettings.json` and `appsettings.local.overrides.json`: Replaced `APPINSIGHTS_INSTRUMENTATIONKEY` with `APPLICATIONINSIGHTS_CONNECTION_STRING`.
- `Program.cs`: Updated logging configuration to use the connection string and removed unused `using` directives.
- `main.tf`: Modified app settings for `webapp_service` and `fulfilment_webapp` modules to use the connection string.
- `outputs.tf`: Removed output for `instrumentation_key` and added output for `connection_string`.
- `.editorconfig`: Added setting for `dotnet_style_readonly_field`.
