### PR TITLE
Remove monitor_product_group_mapping resource

### DIFF
--- a/Deployment/src/Modules/APIM/Modules/ExchangeSetService/main.tf
+++ b/Deployment/src/Modules/APIM/Modules/ExchangeSetService/main.tf
@@ -359,11 +359,3 @@ resource "azurerm_api_management_product_api" "ess_monitor_product_api_mapping" 
   api_name            = azurerm_api_management_api.ess_monitor_api.name
   product_id          = azurerm_api_management_product.ess_monitor_product.product_id
 }
-
-# ESS monitor product-Group mapping
-resource "azurerm_api_management_product_group" "monitor_product_group_mappping" {
-  resource_group_name = data.azurerm_resource_group.rg.name
-  api_management_name = data.azurerm_api_management.apim_instance.name
-  product_id          = azurerm_api_management_product.ess_monitor_product.product_id
-  group_name          = azurerm_api_management_group.ess_management_group.name
-}


### PR DESCRIPTION
The `azurerm_api_management_product_group` resource named `monitor_product_group_mapping` has been removed. This resource mapped the `ess_monitor_product` to the `ess_management_group` in Azure API Management. Attributes removed include `resource_group_name`, `api_management_name`, `product_id`, and `group_name`.

No changes were made to the
`azurerm_api_management_product_api` resource
`ess_monitor_product_api_mapping`.