### PR TITLE
Add tests for fulfiment FileBuilder

### DIFF
--- a/Deployment/src/Modules/FulfilmentScaling/main.tf
+++ b/Deployment/src/Modules/FulfilmentScaling/main.tf
@@ -60,7 +60,7 @@ resource "azurerm_monitor_autoscale_setting" "autoscale_setting_sxs" {
 }
 
 resource "azurerm_monitor_autoscale_setting" "autoscale_setting_mxs" {
-  count               = var.asp_control_mxs.enableAutoScale ? var.exchange_set_config.SmallExchangeSetInstance : 0
+  count               = var.asp_control_mxs.enableAutoScale ? var.exchange_set_config.MediumExchangeSetInstance : 0
   name                = "${var.asp["mxs"][count.index].name}-autoscale"
   resource_group_name = var.resource_group_name
   location            = var.location
@@ -121,7 +121,7 @@ resource "azurerm_monitor_autoscale_setting" "autoscale_setting_mxs" {
 }
 
 resource "azurerm_monitor_autoscale_setting" "autoscale_setting_lxs" {
-  count               = var.asp_control_lxs.enableAutoScale ? var.exchange_set_config.SmallExchangeSetInstance : 0
+  count               = var.asp_control_lxs.enableAutoScale ? var.exchange_set_config.LargeExchangeSetInstance : 0
   name                = "${var.asp["lxs"][count.index].name}-autoscale"
   resource_group_name = var.resource_group_name
   location            = var.location

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/FileBuilders/FileBuilderTest.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/FileBuilders/FileBuilderTest.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
+using System.Linq;
 using System.Threading.Tasks;
 using FakeItEasy;
 using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 using UKHO.ExchangeSetService.Common.Helpers;
+using UKHO.ExchangeSetService.Common.Logging;
 using UKHO.ExchangeSetService.Common.Models.FileShareService.Response;
 using UKHO.ExchangeSetService.Common.Models.SalesCatalogue;
 using UKHO.ExchangeSetService.FulfilmentService.Downloads;
@@ -106,54 +110,224 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.FileBuilders
             A.CallTo(() => _fulfilmentAncillaryFiles.CreateCatalogFile(FakeBatchValue.BatchId, FakeBatchValue.AioExchangeSetEncRootPath, FakeBatchValue.CorrelationId, listFulfilmentAioData, salesCatalogueDataResponse, salesCatalogueProductResponse)).MustHaveHappenedOnceExactly();
         }
 
-        //Task<bool> CreateLargeMediaSerialEncFile(string batchId, string exchangeSetPath, string rootfolder, string correlationId);
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task WhenCreateLargeMediaSerialEncFile_ReturnsBool(bool secondResponse)
+        {
+            var mediaDir1 = A.Fake<IDirectoryInfo>();
+            A.CallTo(() => mediaDir1.Name).Returns(FakeBatchValue.LargeExchangeSetFolderName);
+            A.CallTo(() => mediaDir1.ToString()).Returns(FakeBatchValue.ExchangeSetMediaPath);
+            var mediaDir2 = A.Fake<IDirectoryInfo>();
+            A.CallTo(() => mediaDir2.Name).Returns(FakeBatchValue.LastLargeExchangeSetFolderName);
+            A.CallTo(() => mediaDir2.ToString()).Returns(FakeBatchValue.LastExchangeSetMediaPath);
+            var mediaDir3 = A.Fake<IDirectoryInfo>();
+            A.CallTo(() => mediaDir3.Name).Returns("Not an M directory");
+            A.CallTo(() => mediaDir3.ToString()).Returns(Path.Combine(FakeBatchValue.BatchPath, "Not an M directory"));
 
-        //public async Task<bool> CreateLargeMediaSerialEncFile(string batchId, string exchangeSetPath, string rootfolder, string correlationId)
-        //{
-        //    DateTime createLargeMediaSerialEncFileTaskStartedAt = DateTime.UtcNow;
+            var baseDir1 = A.Fake<IDirectoryInfo>();
+            A.CallTo(() => baseDir1.Name).Returns("B1");
+            A.CallTo(() => baseDir1.ToString()).Returns(Path.Combine(FakeBatchValue.ExchangeSetMediaPath, "B1"));
+            var baseDir2 = A.Fake<IDirectoryInfo>();
+            A.CallTo(() => baseDir2.Name).Returns("B2");
+            A.CallTo(() => baseDir2.ToString()).Returns(Path.Combine(FakeBatchValue.ExchangeSetMediaPath, "B2"));
 
-        //    return await logger.LogStartEndAndElapsedTimeAsync(EventIds.CreateSerialFileRequestStart,
-        //              EventIds.CreateSerialFileRequestCompleted,
-        //              "Create large media serial enc file request for BatchId:{batchId} and _X-Correlation-ID:{CorrelationId}",
-        //              async () =>
-        //              {
-        //                  var rootLastDirectoryPath = fileSystemHelper.GetDirectoryInfo(exchangeSetPath)
-        //                                          .LastOrDefault(di => di.Name.StartsWith("M0"));
+            var lastBaseDir1 = A.Fake<IDirectoryInfo>();
+            A.CallTo(() => lastBaseDir1.Name).Returns("B3");
+            A.CallTo(() => lastBaseDir1.ToString()).Returns(Path.Combine(FakeBatchValue.LastExchangeSetMediaPath, "B3"));
 
-        //                  var baseDirectoryies = fileSystemHelper.GetDirectoryInfo(Path.Combine(exchangeSetPath, rootfolder))
-        //                                          .Where(di => di.Name.StartsWith("B") && di.Name.Length <= 3 && CommonHelper.IsNumeric(di.Name[^(di.Name.Length - 1)..]));
+            // Root directories (to find last M0*)
+            A.CallTo(() => _fakeFileSystemHelper.GetDirectoryInfo(FakeBatchValue.BatchPath)).Returns([mediaDir1, mediaDir2, mediaDir3]);
 
-        //                  var baseLastDirectory = fileSystemHelper.GetDirectoryInfo(rootLastDirectoryPath?.ToString())
-        //                                          .LastOrDefault(di => di.Name.StartsWith("B") && di.Name.Length <= 3 && CommonHelper.IsNumeric(di.Name[^(di.Name.Length - 1)..]));
+            // Base directories under rootfolder
+            A.CallTo(() => _fakeFileSystemHelper.GetDirectoryInfo(FakeBatchValue.ExchangeSetMediaPath)).Returns([baseDir1, baseDir2]);
 
-        //                  string lastBaseDirectoryNumber = baseLastDirectory.ToString().Replace(Path.Combine(rootLastDirectoryPath.ToString(), "B"), "");
+            // For determining last base directory
+            A.CallTo(() => _fakeFileSystemHelper.GetDirectoryInfo(FakeBatchValue.LastExchangeSetMediaPath)).Returns([lastBaseDir1]);
 
-        //                  var ParallelBaseFolderTasks = new List<Task<bool>> { };
-        //                  Parallel.ForEach(baseDirectoryies, baseDirectoryFolder =>
-        //                  {
-        //                      string baseDirectoryNumber = baseDirectoryFolder.ToString().Replace(Path.Combine(exchangeSetPath, rootfolder, "B"), "");
-        //                      ParallelBaseFolderTasks.Add(fulfilmentAncillaryFiles.CreateLargeMediaSerialEncFile(batchId, baseDirectoryFolder.ToString(), correlationId, baseDirectoryNumber.ToString(), lastBaseDirectoryNumber));
-        //                  });
-        //                  await Task.WhenAll(ParallelBaseFolderTasks);
+            A.CallTo(() => _fulfilmentAncillaryFiles.CreateLargeMediaSerialEncFile(FakeBatchValue.BatchId, baseDir1.ToString(), FakeBatchValue.CorrelationId, "1", "3")).Returns(true);
+            A.CallTo(() => _fulfilmentAncillaryFiles.CreateLargeMediaSerialEncFile(FakeBatchValue.BatchId, baseDir2.ToString(), FakeBatchValue.CorrelationId, "2", "3")).Returns(secondResponse);
 
-        //                  DateTime createLargeMediaSerialEncFileTaskCompletedAt = DateTime.UtcNow;
-        //                  monitorHelper.MonitorRequest("Create Large Media Serial Enc File Task", createLargeMediaSerialEncFileTaskStartedAt, createLargeMediaSerialEncFileTaskCompletedAt, correlationId, null, null, null, batchId);
+            var result = await _fileBuilder.CreateLargeMediaSerialEncFile(FakeBatchValue.BatchId, FakeBatchValue.BatchPath, FakeBatchValue.LargeExchangeSetFolderName, FakeBatchValue.CorrelationId);
 
-        //                  return await Task.FromResult(ParallelBaseFolderTasks.All(x => x.Result.Equals(true)));
-        //              },
-        //          batchId, correlationId);
-        //}
+            Assert.That(result, Is.EqualTo(secondResponse));
+            A.CallTo(() => _fakeFileSystemHelper.GetDirectoryInfo(FakeBatchValue.BatchPath)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fakeFileSystemHelper.GetDirectoryInfo(FakeBatchValue.ExchangeSetMediaPath)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fakeFileSystemHelper.GetDirectoryInfo(FakeBatchValue.LastExchangeSetMediaPath)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fulfilmentAncillaryFiles.CreateLargeMediaSerialEncFile(FakeBatchValue.BatchId, baseDir1.ToString(), FakeBatchValue.CorrelationId, "1", "3")).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fulfilmentAncillaryFiles.CreateLargeMediaSerialEncFile(FakeBatchValue.BatchId, baseDir2.ToString(), FakeBatchValue.CorrelationId, "2", "3")).MustHaveHappenedOnceExactly();
+        }
 
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task WhenCreateLargeMediaExchangesetCatalogFile_AllTrue_ReturnsTrue(bool secondResponse)
+        {
+            var salesCatalogueDataResponse = new SalesCatalogueDataResponse();
+            var salesCatalogueProductResponse = new SalesCatalogueProductResponse();
 
+            var baseDir1 = A.Fake<IDirectoryInfo>();
+            A.CallTo(() => baseDir1.Name).Returns("B1");
+            A.CallTo(() => baseDir1.ToString()).Returns(Path.Combine(FakeBatchValue.ExchangeSetMediaPath, "B1"));
+            var baseDir2 = A.Fake<IDirectoryInfo>();
+            A.CallTo(() => baseDir2.Name).Returns("B2");
+            A.CallTo(() => baseDir2.ToString()).Returns(Path.Combine(FakeBatchValue.ExchangeSetMediaPath, "B2"));
+            var baseDir3 = A.Fake<IDirectoryInfo>();
+            A.CallTo(() => baseDir3.Name).Returns("Not a base directory");
+            A.CallTo(() => baseDir3.ToString()).Returns(Path.Combine(FakeBatchValue.ExchangeSetMediaPath, "Not a base directory"));
 
-        //Task<bool> CreateAncillaryFilesForAio(string batchId, string aioExchangeSetPath, string correlationId, SalesCatalogueDataResponse salesCatalogueDataResponse, DateTime scsRequestDateTime, SalesCatalogueProductResponse salesCatalogueProductResponse, List<FulfilmentDataResponse> listFulfilmentAioData);
+            // Base directories at exchangeSetPath
+            A.CallTo(() => _fakeFileSystemHelper.GetDirectoryInfo(FakeBatchValue.ExchangeSetMediaPath)).Returns([baseDir1, baseDir2, baseDir3]);
 
-        //Task<bool> CreateCatalogFile(string batchId, string exchangeSetRootPath, string correlationId, List<FulfilmentDataResponse> listFulfilmentData, SalesCatalogueDataResponse salesCatalogueDataResponse, SalesCatalogueProductResponse salesCatalogueProductResponse);
+            // ENC_ROOT folders under each base
+            var encRoot1 = Path.Combine(baseDir1.ToString(), FakeBatchValue.EncRoot);
+            var encRoot2 = Path.Combine(baseDir2.ToString(), FakeBatchValue.EncRoot);
 
-        //Task<bool> CreateProductFile(string batchId, string exchangeSetInfoPath, string correlationId, SalesCatalogueDataResponse salesCatalogueDataResponse, DateTime scsRequestDateTime, bool encryption);
+            // Country code directories (names whose last 2 chars used)
+            var d1a = A.Fake<IDirectoryInfo>(); A.CallTo(() => d1a.Name).Returns("XXXGB");
+            var d1b = A.Fake<IDirectoryInfo>(); A.CallTo(() => d1b.Name).Returns("YYYFR");
+            var d2a = A.Fake<IDirectoryInfo>(); A.CallTo(() => d2a.Name).Returns("ZZZDE");
 
-        //Task CreateSerialEncFile(string batchId, string exchangeSetPath, string correlationId);
+            A.CallTo(() => _fakeFileSystemHelper.GetDirectoryInfo(encRoot1)).Returns([d1a, d1b]);
+            A.CallTo(() => _fakeFileSystemHelper.GetDirectoryInfo(encRoot2)).Returns([d2a]);
 
-        //Task<bool> CreateLargeMediaExchangesetCatalogFile(string batchId, string exchangeSetPath, string correlationId, List<FulfilmentDataResponse> listFulfilmentData, SalesCatalogueDataResponse salesCatalogueDataResponse, SalesCatalogueProductResponse salesCatalogueProductResponse);
+            var listFulfilmentData = new List<FulfilmentDataResponse>
+            {
+                new() { ProductName = "GB1234" },
+                new() { ProductName = "FR5678" },
+                new() { ProductName = "DE9999" },
+                new() { ProductName = "NO0001" } // should not match
+            };
+
+            A.CallTo(() => _fulfilmentAncillaryFiles.CreateLargeExchangeSetCatalogFile(
+                FakeBatchValue.BatchId, encRoot1, FakeBatchValue.CorrelationId,
+                A<List<FulfilmentDataResponse>>.That.Matches(l => l.Count == 2 && l.Any(p => p.ProductName.StartsWith("GB")) && l.Any(p => p.ProductName.StartsWith("FR"))),
+                salesCatalogueDataResponse, salesCatalogueProductResponse)).Returns(true);
+
+            A.CallTo(() => _fulfilmentAncillaryFiles.CreateLargeExchangeSetCatalogFile(
+                FakeBatchValue.BatchId, encRoot2, FakeBatchValue.CorrelationId,
+                A<List<FulfilmentDataResponse>>.That.Matches(l => l.Count == 1 && l.Single().ProductName.StartsWith("DE")),
+                salesCatalogueDataResponse, salesCatalogueProductResponse)).Returns(secondResponse);
+
+            var result = await _fileBuilder.CreateLargeMediaExchangesetCatalogFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetMediaPath, FakeBatchValue.CorrelationId, listFulfilmentData, salesCatalogueDataResponse, salesCatalogueProductResponse);
+
+            Assert.That(result, Is.EqualTo(secondResponse));
+            A.CallTo(() => _fakeFileSystemHelper.GetDirectoryInfo(FakeBatchValue.ExchangeSetMediaPath)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fulfilmentAncillaryFiles.CreateLargeExchangeSetCatalogFile(
+                FakeBatchValue.BatchId, encRoot1, FakeBatchValue.CorrelationId,
+                A<List<FulfilmentDataResponse>>.That.Matches(l => l.Count == 2 && l.Any(p => p.ProductName.StartsWith("GB")) && l.Any(p => p.ProductName.StartsWith("FR"))),
+                salesCatalogueDataResponse, salesCatalogueProductResponse)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fulfilmentAncillaryFiles.CreateLargeExchangeSetCatalogFile(
+                FakeBatchValue.BatchId, encRoot2, FakeBatchValue.CorrelationId,
+                A<List<FulfilmentDataResponse>>.That.Matches(l => l.Count == 1 && l.Single().ProductName.StartsWith("DE")),
+                salesCatalogueDataResponse, salesCatalogueProductResponse)).MustHaveHappenedOnceExactly();
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task WhenCreateCatalogFileCalled_ThenReturnsExpected(bool expected)
+        {
+            var listFulfilmentData = new List<FulfilmentDataResponse>();
+            var salesCatalogueDataResponse = new SalesCatalogueDataResponse();
+            var salesCatalogueProductResponse = new SalesCatalogueProductResponse();
+            A.CallTo(() => _fulfilmentAncillaryFiles.CreateCatalogFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetEncRootPath, FakeBatchValue.CorrelationId, listFulfilmentData, salesCatalogueDataResponse, salesCatalogueProductResponse)).Returns(expected);
+
+            var result = await _fileBuilder.CreateCatalogFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetEncRootPath, FakeBatchValue.CorrelationId, listFulfilmentData, salesCatalogueDataResponse, salesCatalogueProductResponse);
+
+            Assert.That(result, Is.EqualTo(expected));
+            A.CallTo(() => _fulfilmentAncillaryFiles.CreateCatalogFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetEncRootPath, FakeBatchValue.CorrelationId, listFulfilmentData, salesCatalogueDataResponse, salesCatalogueProductResponse)).MustHaveHappenedOnceExactly();
+        }
+
+        [Test]
+        public async Task WhenCreateCatalogFileWithEmptyPath_ThenReturnsFalse()
+        {
+            var listFulfilmentData = new List<FulfilmentDataResponse>();
+            var salesCatalogueDataResponse = new SalesCatalogueDataResponse();
+            var salesCatalogueProductResponse = new SalesCatalogueProductResponse();
+
+            var result = await _fileBuilder.CreateCatalogFile(FakeBatchValue.BatchId, string.Empty, FakeBatchValue.CorrelationId, listFulfilmentData, salesCatalogueDataResponse, salesCatalogueProductResponse);
+
+            Assert.That(result, Is.False);
+            A.CallTo(() => _fulfilmentAncillaryFiles.CreateCatalogFile(A<string>.Ignored, A<string>.Ignored, A<string>.Ignored, A<List<FulfilmentDataResponse>>.Ignored, A<SalesCatalogueDataResponse>.Ignored, A<SalesCatalogueProductResponse>.Ignored)).MustNotHaveHappened();
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task WhenCreateProductFileCalled_ThenReturnsExpected(bool expected)
+        {
+            var salesCatalogueDataResponse = new SalesCatalogueDataResponse();
+            var scsRequestDateTime = DateTime.UtcNow;
+            A.CallTo(() => _fulfilmentAncillaryFiles.CreateProductFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetInfoPath, FakeBatchValue.CorrelationId, salesCatalogueDataResponse, scsRequestDateTime, true)).Returns(expected);
+
+            var result = await _fileBuilder.CreateProductFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetInfoPath, FakeBatchValue.CorrelationId, salesCatalogueDataResponse, scsRequestDateTime, true);
+
+            Assert.That(result, Is.EqualTo(expected));
+            A.CallTo(() => _fulfilmentAncillaryFiles.CreateProductFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetInfoPath, FakeBatchValue.CorrelationId, salesCatalogueDataResponse, scsRequestDateTime, true)).MustHaveHappenedOnceExactly();
+        }
+
+        [Test]
+        public async Task WhenCreateProductFileWithEmptyPath_ThenReturnsFalse()
+        {
+            var salesCatalogueDataResponse = new SalesCatalogueDataResponse();
+            var scsRequestDateTime = DateTime.UtcNow;
+
+            var result = await _fileBuilder.CreateProductFile(FakeBatchValue.BatchId, string.Empty, FakeBatchValue.CorrelationId, salesCatalogueDataResponse, scsRequestDateTime, false);
+
+            Assert.That(result, Is.False);
+            A.CallTo(() => _fulfilmentAncillaryFiles.CreateProductFile(A<string>.Ignored, A<string>.Ignored, A<string>.Ignored, A<SalesCatalogueDataResponse>.Ignored, A<DateTime>.Ignored, A<bool>.Ignored)).MustNotHaveHappened();
+        }
+
+        [Test]
+        public async Task WhenCreateSerialEncFileCalled_ThenUnderlyingAncillaryIsCalled()
+        {
+            A.CallTo(() => _fulfilmentAncillaryFiles.CreateSerialEncFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetPath, FakeBatchValue.CorrelationId)).Returns(true);
+
+            await _fileBuilder.CreateSerialEncFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetPath, FakeBatchValue.CorrelationId);
+
+            A.CallTo(() => _fulfilmentAncillaryFiles.CreateSerialEncFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetPath, FakeBatchValue.CorrelationId)).MustHaveHappenedOnceExactly();
+        }
+
+        [Test]
+        public async Task WhenCreateAncillaryFilesWithEncryptionTrue_AllExpectedDependenciesCalled()
+        {
+            var listFulfilmentData = new List<FulfilmentDataResponse>();
+            var salesCatalogueDataResponse = new SalesCatalogueDataResponse();
+            var salesCatalogueProductResponse = new SalesCatalogueProductResponse();
+            var scsRequestDateTime = DateTime.UtcNow;
+            A.CallTo(() => _fulfilmentAncillaryFiles.CreateProductFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetInfoPath, FakeBatchValue.CorrelationId, salesCatalogueDataResponse, scsRequestDateTime, true)).Returns(true);
+            A.CallTo(() => _fulfilmentAncillaryFiles.CreateSerialEncFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetPath, FakeBatchValue.CorrelationId)).Returns(true);
+            A.CallTo(() => _downloader.DownloadReadMeFileAsync(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetEncRootPath, FakeBatchValue.CorrelationId)).Returns(true);
+            A.CallTo(() => _fulfilmentAncillaryFiles.CreateCatalogFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetEncRootPath, FakeBatchValue.CorrelationId, listFulfilmentData, salesCatalogueDataResponse, salesCatalogueProductResponse)).Returns(true);
+
+            await _fileBuilder.CreateAncillaryFiles(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetPath, FakeBatchValue.CorrelationId, listFulfilmentData, salesCatalogueProductResponse, scsRequestDateTime, salesCatalogueDataResponse, true);
+
+            A.CallTo(() => _fulfilmentAncillaryFiles.CreateProductFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetInfoPath, FakeBatchValue.CorrelationId, salesCatalogueDataResponse, scsRequestDateTime, true)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fulfilmentAncillaryFiles.CreateSerialEncFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetPath, FakeBatchValue.CorrelationId)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _downloader.DownloadReadMeFileAsync(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetEncRootPath, FakeBatchValue.CorrelationId)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fulfilmentAncillaryFiles.CreateCatalogFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetEncRootPath, FakeBatchValue.CorrelationId, listFulfilmentData, salesCatalogueDataResponse, salesCatalogueProductResponse)).MustHaveHappenedOnceExactly();
+        }
+
+        [Test]
+        public async Task WhenCreateAncillaryFilesWithEncryptionFalse_SerialEncSkipped()
+        {
+            var listFulfilmentData = new List<FulfilmentDataResponse>();
+            var salesCatalogueDataResponse = new SalesCatalogueDataResponse();
+            var salesCatalogueProductResponse = new SalesCatalogueProductResponse();
+            var scsRequestDateTime = DateTime.UtcNow;
+            A.CallTo(() => _fulfilmentAncillaryFiles.CreateProductFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetInfoPath, FakeBatchValue.CorrelationId, salesCatalogueDataResponse, scsRequestDateTime, false)).Returns(true);
+            A.CallTo(() => _downloader.DownloadReadMeFileAsync(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetEncRootPath, FakeBatchValue.CorrelationId)).Returns(true);
+            A.CallTo(() => _fulfilmentAncillaryFiles.CreateCatalogFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetEncRootPath, FakeBatchValue.CorrelationId, listFulfilmentData, salesCatalogueDataResponse, salesCatalogueProductResponse)).Returns(true);
+
+            await _fileBuilder.CreateAncillaryFiles(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetPath, FakeBatchValue.CorrelationId, listFulfilmentData, salesCatalogueProductResponse, scsRequestDateTime, salesCatalogueDataResponse, false);
+
+            A.CallTo(() => _fulfilmentAncillaryFiles.CreateProductFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetInfoPath, FakeBatchValue.CorrelationId, salesCatalogueDataResponse, scsRequestDateTime, false)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fulfilmentAncillaryFiles.CreateSerialEncFile(A<string>.Ignored, A<string>.Ignored, A<string>.Ignored)).MustNotHaveHappened();
+            A.CallTo(() => _downloader.DownloadReadMeFileAsync(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetEncRootPath, FakeBatchValue.CorrelationId)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fulfilmentAncillaryFiles.CreateCatalogFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetEncRootPath, FakeBatchValue.CorrelationId, listFulfilmentData, salesCatalogueDataResponse, salesCatalogueProductResponse)).MustHaveHappenedOnceExactly();
+
+            A.CallTo(_fakeLogger).Where(call => call.Method.Name == "Log" && call.GetArgument<EventId>(1) == EventIds.SerialFileCreationSkipped.ToEventId()).MustHaveHappenedOnceExactly();
+        }
     }
 }

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/TestHelper/FakeBatchValue.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/TestHelper/FakeBatchValue.cs
@@ -34,6 +34,18 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.TestHelper
         /// </summary>
         public const string ExchangeSetMediaBaseNumber = "5";
         /// <summary>
+        /// 6
+        /// </summary>
+        public const string LastExchangeSetMediaBaseNumber = "6";
+        /// <summary>
+        /// M05X02
+        /// </summary>
+        public const string LargeExchangeSetFolderName = $"M0{ExchangeSetMediaBaseNumber}X02";
+        /// <summary>
+        /// M06X02
+        /// </summary>
+        public const string LastLargeExchangeSetFolderName = $"M0{LastExchangeSetMediaBaseNumber}X02";
+        /// <summary>
         /// ENC_ROOT
         /// </summary>
         public const string EncRoot = "ENC_ROOT";
@@ -109,11 +121,15 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.TestHelper
         /// <summary>
         /// C:\HOME\25SEP2025\7b4cdf10-adfa-4ed6-b2fe-d1543d8b7272\M05X02
         /// </summary>
-        public const string ExchangeSetMediaPath = $@"{BatchPath}\M0{ExchangeSetMediaBaseNumber}X02";
+        public const string ExchangeSetMediaPath = $@"{BatchPath}\{LargeExchangeSetFolderName}";
+        /// <summary>
+        /// C:\HOME\25SEP2025\7b4cdf10-adfa-4ed6-b2fe-d1543d8b7272\M06X02
+        /// </summary>
+        public const string LastExchangeSetMediaPath = $@"{BatchPath}\{LastLargeExchangeSetFolderName}";
         /// <summary>
         /// C:\HOME\25SEP2025\7b4cdf10-adfa-4ed6-b2fe-d1543d8b7272\M05X02\INFO
         /// </summary>
-        public const string ExchangeSetMediaInfoPath = $@"{BatchPath}\M0{ExchangeSetMediaBaseNumber}X02\{Info}";
+        public const string ExchangeSetMediaInfoPath = $@"{ExchangeSetMediaPath}\{Info}";
         /// <summary>
         /// C:\HOME\25SEP2025\7b4cdf10-adfa-4ed6-b2fe-d1543d8b7272\M05X02\INFO\ENC Update List.csv
         /// </summary>


### PR DESCRIPTION
#### PR Classification  
New feature and code enhancement to support large exchange sets and improve test coverage.  

#### PR Summary  
This pull request introduces support for large exchange sets, updates Terraform configurations, and adds comprehensive unit tests for improved reliability.  
- **`main.tf`**: Updated `count` property for `azurerm_monitor_autoscale_setting` to use `MediumExchangeSetInstance` and `LargeExchangeSetInstance`.  
- **`FileBuilderTest.cs`**: Added extensive unit tests for `FileBuilder`, covering ancillary file creation, edge cases, and dependency validation.  
- **`FakeBatchValue.cs`**: Introduced new constants and updated path handling to support large exchange set scenarios dynamically.  
