### PR TITLE
Add ExchangeSetBuilder tests

### DIFF
--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/FileBuilders/ExchangeSetBuilderTest.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/FileBuilders/ExchangeSetBuilderTest.cs
@@ -1,0 +1,309 @@
+using System;
+using System.Collections.Generic;
+using System.IO.Abstractions;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FakeItEasy;
+using FluentValidation.Results;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using UKHO.ExchangeSetService.Common.Configuration;
+using UKHO.ExchangeSetService.Common.Helpers;
+using UKHO.ExchangeSetService.Common.Models.FileShareService.Response;
+using UKHO.ExchangeSetService.Common.Models.Response;
+using UKHO.ExchangeSetService.Common.Models.SalesCatalogue;
+using UKHO.ExchangeSetService.FulfilmentService.Downloads;
+using UKHO.ExchangeSetService.FulfilmentService.FileBuilders;
+using UKHO.ExchangeSetService.FulfilmentService.Services;
+using UKHO.ExchangeSetService.FulfilmentService.Validation;
+using UKHO.ExchangeSetService.Webjob.UnitTests.TestHelper;
+
+namespace UKHO.ExchangeSetService.Webjob.UnitTests.FileBuilders
+{
+    [TestFixture]
+    public class ExchangeSetBuilderTest
+    {
+        private ILogger<FulfilmentDataService> _fakeLogger;
+        private IMonitorHelper _fakeMonitorHelper;
+        private IFileSystemHelper _fakeFileSystemHelper;
+        private IProductDataValidator _fakeProductDataValidator;
+        private IOptions<FileShareServiceConfiguration> _fileShareServiceConfiguration;
+        private IOptions<AioConfiguration> _aioConfiguration;
+        private IFulfilmentFileShareService _fakeFulfilmentFileShareService;
+        private IFulfilmentAncillaryFiles _fakeFulfilmentAncillaryFiles;
+        private IFileBuilder _fakeFileBuilder;
+        private IDownloader _fakeDownloader;
+        private ExchangeSetBuilder _exchangeSetBuilder;
+
+        private static SalesCatalogueServiceResponseQueueMessage CreateMessage() =>
+            new()
+            {
+                BatchId = FakeBatchValue.BatchId,
+                CorrelationId = FakeBatchValue.CorrelationId,
+                ScsRequestDateTime = DateTime.UtcNow,
+                ExchangeSetStandard = "s63"
+            };
+
+        private static List<Products> CreateProducts(int count = 2, string prefix = "GB")
+        {
+            var list = new List<Products>();
+
+            for (var i = 1; i <= count; i++)
+            {
+                list.Add(new Products
+                {
+                    ProductName = $"{prefix}{800000 + i + 1}",
+                    EditionNumber = 1,
+                    UpdateNumbers = [0],
+                    FileSize = 100
+                });
+            }
+
+            return list;
+        }
+
+        private static List<Products> CreateProductsAio()
+        {
+            return
+            [
+                new()
+                {
+                    ProductName = FakeBatchValue.AioCells,
+                    EditionNumber = 1,
+                    UpdateNumbers = [0],
+                    FileSize = 100
+                }
+            ];
+        }
+
+        private static List<FulfilmentDataResponse> CreateFulfilmentDataResponses(List<Products> products)
+        {
+            return [.. products.Select((p, idx) => new FulfilmentDataResponse
+            {
+                BatchId = FakeBatchValue.BatchId,
+                ProductName = p.ProductName,
+                EditionNumber = p.EditionNumber ?? 1,
+                UpdateNumber = p.UpdateNumbers.First() ?? 0,
+                Files = new List<BatchFile>(),
+                FileShareServiceSearchQueryCount = idx == 0 ? 1 : 0
+            })];
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            _fakeLogger = A.Fake<ILogger<FulfilmentDataService>>();
+            _fakeMonitorHelper = A.Fake<IMonitorHelper>();
+            _fakeFileSystemHelper = A.Fake<IFileSystemHelper>();
+            _fakeProductDataValidator = A.Fake<IProductDataValidator>();
+            _fileShareServiceConfiguration = FakeBatchValue.FileShareServiceConfiguration;
+            _aioConfiguration = Options.Create(new AioConfiguration { AioCells = FakeBatchValue.AioCells }); // one AIO cell
+            _fakeFulfilmentFileShareService = A.Fake<IFulfilmentFileShareService>();
+            _fakeFulfilmentAncillaryFiles = A.Fake<IFulfilmentAncillaryFiles>();
+            _fakeFileBuilder = A.Fake<IFileBuilder>();
+            _fakeDownloader = A.Fake<IDownloader>();
+
+            _exchangeSetBuilder = new ExchangeSetBuilder(_fakeLogger, _fakeMonitorHelper, _fakeFileSystemHelper, _fakeProductDataValidator, FakeBatchValue.FileShareServiceConfiguration, _aioConfiguration, _fakeFulfilmentFileShareService, _fakeFulfilmentAncillaryFiles, _fakeFileBuilder, _fakeDownloader);
+        }
+
+        [Test]
+        public async Task WhenCreateAioExchangeSet_WithProducts_ReturnsTrueAndQueriesFss()
+        {
+            var message = CreateMessage();
+            var products = CreateProductsAio();
+            var fulfilmentDataResponses = CreateFulfilmentDataResponses(products);
+            var salesCatalogueDataResponse = new SalesCatalogueDataResponse();
+            var salesCatalogueProductResponse = new SalesCatalogueProductResponse();
+
+            A.CallTo(() => _fakeFulfilmentFileShareService.QueryFileShareServiceData(A<List<Products>>.Ignored, message, A<CancellationTokenSource>.Ignored, A<CancellationToken>.Ignored, FakeBatchValue.AioExchangeSetEncRootPath, FakeBatchValue.S63BusinessUnit)).Returns(fulfilmentDataResponses);
+            A.CallTo(() => _fakeFileBuilder.CreateAncillaryFilesForAio(FakeBatchValue.BatchId, FakeBatchValue.AioExchangeSetPath, FakeBatchValue.CorrelationId, salesCatalogueDataResponse, message.ScsRequestDateTime, salesCatalogueProductResponse, A<List<FulfilmentDataResponse>>.That.Matches(l => l.Count == fulfilmentDataResponses.Count))).Returns(true);
+
+            var result = await _exchangeSetBuilder.CreateAioExchangeSet(message, FakeBatchValue.CurrentUtcDate, FakeBatchValue.HomeDirectoryPath, products, salesCatalogueDataResponse, salesCatalogueProductResponse);
+
+            Assert.That(result, Is.True);
+            A.CallTo(() => _fakeFulfilmentFileShareService.QueryFileShareServiceData(A<List<Products>>.Ignored, message, A<CancellationTokenSource>.Ignored, A<CancellationToken>.Ignored, FakeBatchValue.AioExchangeSetEncRootPath, FakeBatchValue.S63BusinessUnit)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fakeFileBuilder.CreateAncillaryFilesForAio(FakeBatchValue.BatchId, FakeBatchValue.AioExchangeSetPath, FakeBatchValue.CorrelationId, salesCatalogueDataResponse, message.ScsRequestDateTime, salesCatalogueProductResponse, A<List<FulfilmentDataResponse>>.That.Matches(l => l.Count == fulfilmentDataResponses.Count))).MustHaveHappenedOnceExactly();
+        }
+
+        [Test]
+        public async Task WhenCreateAioExchangeSet_WithEmptyProducts_DoesNotQueryFssButStillCreatesAncillary()
+        {
+            var message = CreateMessage();
+            var empty = new List<Products>();
+            var salesCatalogueDataResponse = new SalesCatalogueDataResponse();
+            var salesCatalogueProductResponse = new SalesCatalogueProductResponse();
+
+            A.CallTo(() => _fakeFileBuilder.CreateAncillaryFilesForAio(FakeBatchValue.BatchId, FakeBatchValue.AioExchangeSetPath, FakeBatchValue.CorrelationId, salesCatalogueDataResponse, message.ScsRequestDateTime, salesCatalogueProductResponse, A<List<FulfilmentDataResponse>>.That.Matches(l => l.Count == 0))).Returns(true);
+
+            var result = await _exchangeSetBuilder.CreateAioExchangeSet(message, FakeBatchValue.CurrentUtcDate, FakeBatchValue.HomeDirectoryPath, empty, salesCatalogueDataResponse, salesCatalogueProductResponse);
+
+            Assert.That(result, Is.True);
+            A.CallTo(() => _fakeFulfilmentFileShareService.QueryFileShareServiceData(A<List<Products>>.Ignored, A<SalesCatalogueServiceResponseQueueMessage>.Ignored, A<CancellationTokenSource>.Ignored, A<CancellationToken>.Ignored, A<string>.Ignored, A<string>.Ignored)).MustNotHaveHappened();
+            A.CallTo(() => _fakeFileBuilder.CreateAncillaryFilesForAio(FakeBatchValue.BatchId, FakeBatchValue.AioExchangeSetPath, FakeBatchValue.CorrelationId, salesCatalogueDataResponse, message.ScsRequestDateTime, salesCatalogueProductResponse, A<List<FulfilmentDataResponse>>.That.Matches(l => l.Count == 0))).MustHaveHappenedOnceExactly();
+        }
+
+        [Test]
+        public async Task WhenCreateStandardExchangeSet_WithS63BusinessUnit_EncryptionTrue()
+        {
+            var message = CreateMessage();
+            var products = CreateProducts();
+            var fulfilmentDataResponses = CreateFulfilmentDataResponses(products);
+            var salesCatalogueDataResponse = new SalesCatalogueDataResponse();
+            var salesCatalogueProductResponse = new SalesCatalogueProductResponse();
+
+            A.CallTo(() => _fakeFulfilmentFileShareService.QueryFileShareServiceData(A<List<Products>>.Ignored, message, A<CancellationTokenSource>.Ignored, A<CancellationToken>.Ignored, FakeBatchValue.ExchangeSetEncRootPath, FakeBatchValue.S63BusinessUnit)).Returns(fulfilmentDataResponses);
+
+            await _exchangeSetBuilder.CreateStandardExchangeSet(message, salesCatalogueProductResponse, products, FakeBatchValue.ExchangeSetPath, salesCatalogueDataResponse, FakeBatchValue.S63BusinessUnit);
+
+            A.CallTo(() => _fakeFulfilmentFileShareService.QueryFileShareServiceData(A<List<Products>>.Ignored, message, A<CancellationTokenSource>.Ignored, A<CancellationToken>.Ignored, FakeBatchValue.ExchangeSetEncRootPath, FakeBatchValue.S63BusinessUnit)).MustHaveHappened(products.Count, Times.Exactly);
+            A.CallTo(() => _fakeFileBuilder.CreateAncillaryFiles(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetPath, FakeBatchValue.CorrelationId, A<List<FulfilmentDataResponse>>.Ignored, salesCatalogueProductResponse, message.ScsRequestDateTime, salesCatalogueDataResponse, true)).MustHaveHappenedOnceExactly();
+        }
+
+        [Test]
+        public async Task WhenCreateStandardExchangeSet_WithS57BusinessUnit_EncryptionFalse()
+        {
+            var message = CreateMessage();
+            var products = CreateProducts();
+            var fulfilmentDataResponses = CreateFulfilmentDataResponses(products);
+            var salesCatalogueDataResponse = new SalesCatalogueDataResponse();
+            var salesCatalogueProductResponse = new SalesCatalogueProductResponse();
+
+            A.CallTo(() => _fakeFulfilmentFileShareService.QueryFileShareServiceData(A<List<Products>>.Ignored, message, A<CancellationTokenSource>.Ignored, A<CancellationToken>.Ignored, FakeBatchValue.ExchangeSetEncRootPath, FakeBatchValue.S57BusinessUnit)).Returns(fulfilmentDataResponses);
+
+            await _exchangeSetBuilder.CreateStandardExchangeSet(message, salesCatalogueProductResponse, products, FakeBatchValue.ExchangeSetPath, salesCatalogueDataResponse, FakeBatchValue.S57BusinessUnit);
+
+            A.CallTo(() => _fakeFulfilmentFileShareService.QueryFileShareServiceData(A<List<Products>>.Ignored, message, A<CancellationTokenSource>.Ignored, A<CancellationToken>.Ignored, FakeBatchValue.ExchangeSetEncRootPath, FakeBatchValue.S57BusinessUnit)).MustHaveHappened(products.Count, Times.Exactly);
+            A.CallTo(() => _fakeFileBuilder.CreateAncillaryFiles(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetPath, FakeBatchValue.CorrelationId, A<List<FulfilmentDataResponse>>.Ignored, salesCatalogueProductResponse, message.ScsRequestDateTime, salesCatalogueDataResponse, false)).MustHaveHappenedOnceExactly();
+        }
+
+        [Test]
+        public async Task WhenCreateStandardExchangeSet_WithEmptyProducts_DoesNotQueryFssButStillCreatesAncillary()
+        {
+            var message = CreateMessage();
+            var empty = new List<Products>();
+            var salesCatalogueDataResponse = new SalesCatalogueDataResponse();
+            var salesCatalogueProductResponse = new SalesCatalogueProductResponse();
+
+            await _exchangeSetBuilder.CreateStandardExchangeSet(message, salesCatalogueProductResponse, empty, FakeBatchValue.ExchangeSetPath, salesCatalogueDataResponse, FakeBatchValue.S57BusinessUnit);
+
+            A.CallTo(() => _fakeFulfilmentFileShareService.QueryFileShareServiceData(A<List<Products>>.Ignored, A<SalesCatalogueServiceResponseQueueMessage>.Ignored, A<CancellationTokenSource>.Ignored, A<CancellationToken>.Ignored, A<string>.Ignored, A<string>.Ignored)).MustNotHaveHappened();
+            A.CallTo(() => _fakeFileBuilder.CreateAncillaryFiles(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetPath, FakeBatchValue.CorrelationId, A<List<FulfilmentDataResponse>>.Ignored, salesCatalogueProductResponse, message.ScsRequestDateTime, salesCatalogueDataResponse, false)).MustHaveHappenedOnceExactly();
+        }
+
+        [Test]
+        public async Task WhenCreateStandardLargeMediaExchangeSet_Valid_ReturnsTrue()
+        {
+            var message = CreateMessage();
+            var products = CreateProducts(1); // one non-AIO cell
+            var fulfilmentDataResponses = CreateFulfilmentDataResponses(products);
+            var salesCatalogueDataResponse = new SalesCatalogueDataResponse();
+            var salesCatalogueProductResponse = new SalesCatalogueProductResponse { Products = products };
+            var largeExchangeSetDataResponse = new LargeExchangeSetDataResponse
+            {
+                SalesCatalogueProductResponse = salesCatalogueProductResponse,
+                SalesCatalogueDataResponse = salesCatalogueDataResponse
+            };
+
+            // Validation passes
+            A.CallTo(() => _fakeProductDataValidator.Validate(A<List<Products>>.Ignored)).Returns(Task.FromResult(new ValidationResult()));
+
+            // Query to FSS returns fulfilment data
+            A.CallTo(() => _fakeFulfilmentFileShareService.QueryFileShareServiceData(A<List<Products>>.Ignored, message, A<CancellationTokenSource>.Ignored, A<CancellationToken>.Ignored, FakeBatchValue.LargeExchangeSetEncRootPattern, FakeBatchValue.S63BusinessUnit)).Returns(fulfilmentDataResponses);
+
+            // Root M0* directories
+            var m05 = A.Fake<IDirectoryInfo>();
+            A.CallTo(() => m05.Name).Returns(FakeBatchValue.LargeExchangeSetFolderName5);
+            A.CallTo(() => m05.ToString()).Returns(FakeBatchValue.LargeExchangeSetMediaPath5);
+            var m06 = A.Fake<IDirectoryInfo>();
+            A.CallTo(() => m06.Name).Returns(FakeBatchValue.LargeExchangeSetFolderName6);
+            A.CallTo(() => m06.ToString()).Returns(FakeBatchValue.LargeExchangeSetMediaPath6);
+
+            A.CallTo(() => _fakeFileSystemHelper.GetDirectoryInfo(FakeBatchValue.BatchPath)).Returns([m05, m06]);
+
+            // Ancillary / file builder & downloader calls
+            A.CallTo(() => _fakeFulfilmentAncillaryFiles.CreateMediaFile(FakeBatchValue.BatchId, FakeBatchValue.LargeExchangeSetMediaPath5, FakeBatchValue.CorrelationId, FakeBatchValue.MediaBaseNumber5)).Returns(Task.FromResult(true));
+            A.CallTo(() => _fakeFulfilmentAncillaryFiles.CreateMediaFile(FakeBatchValue.BatchId, FakeBatchValue.LargeExchangeSetMediaPath6, FakeBatchValue.CorrelationId, FakeBatchValue.MediaBaseNumber6)).Returns(Task.FromResult(true));
+            A.CallTo(() => _fakeDownloader.DownloadLargeMediaReadMeFile(FakeBatchValue.BatchId, FakeBatchValue.LargeExchangeSetMediaPath5, FakeBatchValue.CorrelationId)).Returns(Task.CompletedTask);
+            A.CallTo(() => _fakeDownloader.DownloadLargeMediaReadMeFile(FakeBatchValue.BatchId, FakeBatchValue.LargeExchangeSetMediaPath6, FakeBatchValue.CorrelationId)).Returns(Task.CompletedTask);
+            A.CallTo(() => _fakeFileBuilder.CreateLargeMediaSerialEncFile(FakeBatchValue.BatchId, FakeBatchValue.BatchPath, FakeBatchValue.LargeExchangeSetFolderName5, FakeBatchValue.CorrelationId)).Returns(Task.FromResult(true));
+            A.CallTo(() => _fakeFileBuilder.CreateLargeMediaSerialEncFile(FakeBatchValue.BatchId, FakeBatchValue.BatchPath, FakeBatchValue.LargeExchangeSetFolderName6, FakeBatchValue.CorrelationId)).Returns(Task.FromResult(true));
+            A.CallTo(() => _fakeFileBuilder.CreateProductFile(FakeBatchValue.BatchId, FakeBatchValue.LargeExchangeSetMediaInfoPath5, FakeBatchValue.CorrelationId, salesCatalogueDataResponse, message.ScsRequestDateTime, true)).Returns(Task.FromResult(true));
+            A.CallTo(() => _fakeFileBuilder.CreateProductFile(FakeBatchValue.BatchId, FakeBatchValue.LargeExchangeSetMediaInfoPath6, FakeBatchValue.CorrelationId, salesCatalogueDataResponse, message.ScsRequestDateTime, true)).Returns(Task.FromResult(true));
+            A.CallTo(() => _fakeDownloader.DownloadInfoFolderFiles(FakeBatchValue.BatchId, FakeBatchValue.LargeExchangeSetMediaInfoPath5, FakeBatchValue.CorrelationId)).Returns(Task.CompletedTask);
+            A.CallTo(() => _fakeDownloader.DownloadInfoFolderFiles(FakeBatchValue.BatchId, FakeBatchValue.LargeExchangeSetMediaInfoPath6, FakeBatchValue.CorrelationId)).Returns(Task.CompletedTask);
+            A.CallTo(() => _fakeDownloader.DownloadAdcFolderFiles(FakeBatchValue.BatchId, FakeBatchValue.LargeExchangeSetMediaInfoAdcPath5, FakeBatchValue.CorrelationId)).Returns(Task.CompletedTask);
+            A.CallTo(() => _fakeDownloader.DownloadAdcFolderFiles(FakeBatchValue.BatchId, FakeBatchValue.LargeExchangeSetMediaInfoAdcPath6, FakeBatchValue.CorrelationId)).Returns(Task.CompletedTask);
+            A.CallTo(() => _fakeFulfilmentAncillaryFiles.CreateEncUpdateCsv(salesCatalogueDataResponse, FakeBatchValue.LargeExchangeSetMediaInfoPath5, FakeBatchValue.BatchId, FakeBatchValue.CorrelationId)).Returns(Task.FromResult(true));
+            A.CallTo(() => _fakeFulfilmentAncillaryFiles.CreateEncUpdateCsv(salesCatalogueDataResponse, FakeBatchValue.LargeExchangeSetMediaInfoPath6, FakeBatchValue.BatchId, FakeBatchValue.CorrelationId)).Returns(Task.FromResult(true));
+            A.CallTo(() => _fakeFileBuilder.CreateLargeMediaExchangesetCatalogFile(FakeBatchValue.BatchId, FakeBatchValue.LargeExchangeSetMediaPath5, FakeBatchValue.CorrelationId, fulfilmentDataResponses, salesCatalogueDataResponse, salesCatalogueProductResponse)).Returns(Task.FromResult(true));
+            A.CallTo(() => _fakeFileBuilder.CreateLargeMediaExchangesetCatalogFile(FakeBatchValue.BatchId, FakeBatchValue.LargeExchangeSetMediaPath6, FakeBatchValue.CorrelationId, fulfilmentDataResponses, salesCatalogueDataResponse, salesCatalogueProductResponse)).Returns(Task.FromResult(true));
+
+            var result = await _exchangeSetBuilder.CreateStandardLargeMediaExchangeSet(message, FakeBatchValue.HomeDirectoryPath, FakeBatchValue.CurrentUtcDate, largeExchangeSetDataResponse, FakeBatchValue.LargeExchangeSetFolderNamePattern, FakeBatchValue.BatchPath);
+
+            Assert.That(result, Is.True);
+            A.CallTo(() => _fakeFulfilmentFileShareService.QueryFileShareServiceData(A<List<Products>>.Ignored, message, A<CancellationTokenSource>.Ignored, A<CancellationToken>.Ignored, FakeBatchValue.LargeExchangeSetEncRootPattern, FakeBatchValue.S63BusinessUnit)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fakeFileSystemHelper.GetDirectoryInfo(FakeBatchValue.BatchPath)).MustHaveHappenedOnceExactly();
+
+            // The following calls are made twice, once per M0* directory
+            A.CallTo(() => _fakeFileSystemHelper.CheckAndCreateFolder(FakeBatchValue.LargeExchangeSetMediaPath5)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fakeFileSystemHelper.CheckAndCreateFolder(FakeBatchValue.LargeExchangeSetMediaInfoPath5)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fakeFileSystemHelper.CheckAndCreateFolder(FakeBatchValue.LargeExchangeSetMediaInfoAdcPath5)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fakeFileSystemHelper.CheckAndCreateFolder(FakeBatchValue.LargeExchangeSetMediaPath6)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fakeFileSystemHelper.CheckAndCreateFolder(FakeBatchValue.LargeExchangeSetMediaInfoPath6)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fakeFileSystemHelper.CheckAndCreateFolder(FakeBatchValue.LargeExchangeSetMediaInfoAdcPath6)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fakeFulfilmentAncillaryFiles.CreateMediaFile(FakeBatchValue.BatchId, FakeBatchValue.LargeExchangeSetMediaPath5, FakeBatchValue.CorrelationId, FakeBatchValue.MediaBaseNumber5)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fakeFulfilmentAncillaryFiles.CreateMediaFile(FakeBatchValue.BatchId, FakeBatchValue.LargeExchangeSetMediaPath6, FakeBatchValue.CorrelationId, FakeBatchValue.MediaBaseNumber6)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fakeDownloader.DownloadLargeMediaReadMeFile(FakeBatchValue.BatchId, FakeBatchValue.LargeExchangeSetMediaPath5, FakeBatchValue.CorrelationId)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fakeDownloader.DownloadLargeMediaReadMeFile(FakeBatchValue.BatchId, FakeBatchValue.LargeExchangeSetMediaPath6, FakeBatchValue.CorrelationId)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fakeFileBuilder.CreateLargeMediaSerialEncFile(FakeBatchValue.BatchId, FakeBatchValue.BatchPath, FakeBatchValue.LargeExchangeSetFolderName5, FakeBatchValue.CorrelationId)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fakeFileBuilder.CreateLargeMediaSerialEncFile(FakeBatchValue.BatchId, FakeBatchValue.BatchPath, FakeBatchValue.LargeExchangeSetFolderName6, FakeBatchValue.CorrelationId)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fakeFileBuilder.CreateProductFile(FakeBatchValue.BatchId, FakeBatchValue.LargeExchangeSetMediaInfoPath5, FakeBatchValue.CorrelationId, salesCatalogueDataResponse, message.ScsRequestDateTime, true)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fakeFileBuilder.CreateProductFile(FakeBatchValue.BatchId, FakeBatchValue.LargeExchangeSetMediaInfoPath6, FakeBatchValue.CorrelationId, salesCatalogueDataResponse, message.ScsRequestDateTime, true)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fakeDownloader.DownloadInfoFolderFiles(FakeBatchValue.BatchId, FakeBatchValue.LargeExchangeSetMediaInfoPath5, FakeBatchValue.CorrelationId)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fakeDownloader.DownloadInfoFolderFiles(FakeBatchValue.BatchId, FakeBatchValue.LargeExchangeSetMediaInfoPath6, FakeBatchValue.CorrelationId)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fakeDownloader.DownloadAdcFolderFiles(FakeBatchValue.BatchId, FakeBatchValue.LargeExchangeSetMediaInfoAdcPath5, FakeBatchValue.CorrelationId)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fakeDownloader.DownloadAdcFolderFiles(FakeBatchValue.BatchId, FakeBatchValue.LargeExchangeSetMediaInfoAdcPath6, FakeBatchValue.CorrelationId)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fakeFulfilmentAncillaryFiles.CreateEncUpdateCsv(salesCatalogueDataResponse, FakeBatchValue.LargeExchangeSetMediaInfoPath5, FakeBatchValue.BatchId, FakeBatchValue.CorrelationId)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fakeFulfilmentAncillaryFiles.CreateEncUpdateCsv(salesCatalogueDataResponse, FakeBatchValue.LargeExchangeSetMediaInfoPath6, FakeBatchValue.BatchId, FakeBatchValue.CorrelationId)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fakeFileBuilder.CreateLargeMediaExchangesetCatalogFile(FakeBatchValue.BatchId, FakeBatchValue.LargeExchangeSetMediaPath5, FakeBatchValue.CorrelationId, fulfilmentDataResponses, salesCatalogueDataResponse, salesCatalogueProductResponse)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fakeFileBuilder.CreateLargeMediaExchangesetCatalogFile(FakeBatchValue.BatchId, FakeBatchValue.LargeExchangeSetMediaPath6, FakeBatchValue.CorrelationId, fulfilmentDataResponses, salesCatalogueDataResponse, salesCatalogueProductResponse)).MustHaveHappenedOnceExactly();
+        }
+
+        [Test]
+        public void WhenCreateStandardLargeMediaExchangeSet_ProductValidationFails_ThrowsFulfilmentException()
+        {
+            var message = CreateMessage();
+            var salesCatalogueProductResponse = new SalesCatalogueProductResponse { Products = CreateProducts(1) };
+            var largeResponse = new LargeExchangeSetDataResponse
+            {
+                SalesCatalogueProductResponse = salesCatalogueProductResponse,
+                SalesCatalogueDataResponse = new SalesCatalogueDataResponse()
+            };
+
+            // Validation returns error
+            var validationResult = new ValidationResult(new List<ValidationFailure> { new("ProductName", "Invalid product") });
+
+            A.CallTo(() => _fakeProductDataValidator.Validate(A<List<Products>>.Ignored)).Returns(Task.FromResult(validationResult));
+
+            Assert.ThrowsAsync<FulfilmentException>(async () => await _exchangeSetBuilder.CreateStandardLargeMediaExchangeSet(message, FakeBatchValue.HomeDirectoryPath, FakeBatchValue.CurrentUtcDate, largeResponse, FakeBatchValue.LargeExchangeSetFolderNamePattern, FakeBatchValue.BatchPath));
+        }
+
+        [Test]
+        public async Task WhenQueryFileShareServiceFiles_ReturnsFulfilmentData()
+        {
+            var message = CreateMessage();
+            var products = CreateProducts(1);
+            var fulfilmentDataResponses = CreateFulfilmentDataResponses(products);
+            var cancellationTokenSource = new CancellationTokenSource();
+
+            A.CallTo(() => _fakeFulfilmentFileShareService.QueryFileShareServiceData(products, message, cancellationTokenSource, cancellationTokenSource.Token, FakeBatchValue.ExchangeSetEncRootPath, FakeBatchValue.S63BusinessUnit)).Returns(fulfilmentDataResponses);
+
+            var result = await _exchangeSetBuilder.QueryFileShareServiceFiles(message, products, FakeBatchValue.ExchangeSetEncRootPath, cancellationTokenSource, cancellationTokenSource.Token, FakeBatchValue.S63BusinessUnit);
+
+            Assert.That(result, Is.EqualTo(fulfilmentDataResponses));
+            A.CallTo(() => _fakeFulfilmentFileShareService.QueryFileShareServiceData(products, message, cancellationTokenSource, cancellationTokenSource.Token, FakeBatchValue.ExchangeSetEncRootPath, FakeBatchValue.S63BusinessUnit)).MustHaveHappenedOnceExactly();
+        }
+    }
+}

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/FileBuilders/FileBuilderTest.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/FileBuilders/FileBuilderTest.cs
@@ -116,44 +116,44 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.FileBuilders
         public async Task WhenCreateLargeMediaSerialEncFile_ReturnsBool(bool secondResponse)
         {
             var mediaDir1 = A.Fake<IDirectoryInfo>();
-            A.CallTo(() => mediaDir1.Name).Returns(FakeBatchValue.LargeExchangeSetFolderName);
-            A.CallTo(() => mediaDir1.ToString()).Returns(FakeBatchValue.ExchangeSetMediaPath);
+            A.CallTo(() => mediaDir1.Name).Returns(FakeBatchValue.LargeExchangeSetFolderName5);
+            A.CallTo(() => mediaDir1.ToString()).Returns(FakeBatchValue.LargeExchangeSetMediaPath5);
             var mediaDir2 = A.Fake<IDirectoryInfo>();
-            A.CallTo(() => mediaDir2.Name).Returns(FakeBatchValue.LastLargeExchangeSetFolderName);
-            A.CallTo(() => mediaDir2.ToString()).Returns(FakeBatchValue.LastExchangeSetMediaPath);
+            A.CallTo(() => mediaDir2.Name).Returns(FakeBatchValue.LargeExchangeSetFolderName6);
+            A.CallTo(() => mediaDir2.ToString()).Returns(FakeBatchValue.LargeExchangeSetMediaPath6);
             var mediaDir3 = A.Fake<IDirectoryInfo>();
             A.CallTo(() => mediaDir3.Name).Returns("Not an M directory");
             A.CallTo(() => mediaDir3.ToString()).Returns(Path.Combine(FakeBatchValue.BatchPath, "Not an M directory"));
 
             var baseDir1 = A.Fake<IDirectoryInfo>();
             A.CallTo(() => baseDir1.Name).Returns("B1");
-            A.CallTo(() => baseDir1.ToString()).Returns(Path.Combine(FakeBatchValue.ExchangeSetMediaPath, "B1"));
+            A.CallTo(() => baseDir1.ToString()).Returns(Path.Combine(FakeBatchValue.LargeExchangeSetMediaPath5, "B1"));
             var baseDir2 = A.Fake<IDirectoryInfo>();
             A.CallTo(() => baseDir2.Name).Returns("B2");
-            A.CallTo(() => baseDir2.ToString()).Returns(Path.Combine(FakeBatchValue.ExchangeSetMediaPath, "B2"));
+            A.CallTo(() => baseDir2.ToString()).Returns(Path.Combine(FakeBatchValue.LargeExchangeSetMediaPath5, "B2"));
 
             var lastBaseDir1 = A.Fake<IDirectoryInfo>();
             A.CallTo(() => lastBaseDir1.Name).Returns("B3");
-            A.CallTo(() => lastBaseDir1.ToString()).Returns(Path.Combine(FakeBatchValue.LastExchangeSetMediaPath, "B3"));
+            A.CallTo(() => lastBaseDir1.ToString()).Returns(Path.Combine(FakeBatchValue.LargeExchangeSetMediaPath6, "B3"));
 
             // Root directories (to find last M0*)
             A.CallTo(() => _fakeFileSystemHelper.GetDirectoryInfo(FakeBatchValue.BatchPath)).Returns([mediaDir1, mediaDir2, mediaDir3]);
 
             // Base directories under rootfolder
-            A.CallTo(() => _fakeFileSystemHelper.GetDirectoryInfo(FakeBatchValue.ExchangeSetMediaPath)).Returns([baseDir1, baseDir2]);
+            A.CallTo(() => _fakeFileSystemHelper.GetDirectoryInfo(FakeBatchValue.LargeExchangeSetMediaPath5)).Returns([baseDir1, baseDir2]);
 
             // For determining last base directory
-            A.CallTo(() => _fakeFileSystemHelper.GetDirectoryInfo(FakeBatchValue.LastExchangeSetMediaPath)).Returns([lastBaseDir1]);
+            A.CallTo(() => _fakeFileSystemHelper.GetDirectoryInfo(FakeBatchValue.LargeExchangeSetMediaPath6)).Returns([lastBaseDir1]);
 
             A.CallTo(() => _fulfilmentAncillaryFiles.CreateLargeMediaSerialEncFile(FakeBatchValue.BatchId, baseDir1.ToString(), FakeBatchValue.CorrelationId, "1", "3")).Returns(true);
             A.CallTo(() => _fulfilmentAncillaryFiles.CreateLargeMediaSerialEncFile(FakeBatchValue.BatchId, baseDir2.ToString(), FakeBatchValue.CorrelationId, "2", "3")).Returns(secondResponse);
 
-            var result = await _fileBuilder.CreateLargeMediaSerialEncFile(FakeBatchValue.BatchId, FakeBatchValue.BatchPath, FakeBatchValue.LargeExchangeSetFolderName, FakeBatchValue.CorrelationId);
+            var result = await _fileBuilder.CreateLargeMediaSerialEncFile(FakeBatchValue.BatchId, FakeBatchValue.BatchPath, FakeBatchValue.LargeExchangeSetFolderName5, FakeBatchValue.CorrelationId);
 
             Assert.That(result, Is.EqualTo(secondResponse));
             A.CallTo(() => _fakeFileSystemHelper.GetDirectoryInfo(FakeBatchValue.BatchPath)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => _fakeFileSystemHelper.GetDirectoryInfo(FakeBatchValue.ExchangeSetMediaPath)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => _fakeFileSystemHelper.GetDirectoryInfo(FakeBatchValue.LastExchangeSetMediaPath)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fakeFileSystemHelper.GetDirectoryInfo(FakeBatchValue.LargeExchangeSetMediaPath5)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fakeFileSystemHelper.GetDirectoryInfo(FakeBatchValue.LargeExchangeSetMediaPath6)).MustHaveHappenedOnceExactly();
             A.CallTo(() => _fulfilmentAncillaryFiles.CreateLargeMediaSerialEncFile(FakeBatchValue.BatchId, baseDir1.ToString(), FakeBatchValue.CorrelationId, "1", "3")).MustHaveHappenedOnceExactly();
             A.CallTo(() => _fulfilmentAncillaryFiles.CreateLargeMediaSerialEncFile(FakeBatchValue.BatchId, baseDir2.ToString(), FakeBatchValue.CorrelationId, "2", "3")).MustHaveHappenedOnceExactly();
         }
@@ -168,16 +168,16 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.FileBuilders
 
             var baseDir1 = A.Fake<IDirectoryInfo>();
             A.CallTo(() => baseDir1.Name).Returns("B1");
-            A.CallTo(() => baseDir1.ToString()).Returns(Path.Combine(FakeBatchValue.ExchangeSetMediaPath, "B1"));
+            A.CallTo(() => baseDir1.ToString()).Returns(Path.Combine(FakeBatchValue.LargeExchangeSetMediaPath5, "B1"));
             var baseDir2 = A.Fake<IDirectoryInfo>();
             A.CallTo(() => baseDir2.Name).Returns("B2");
-            A.CallTo(() => baseDir2.ToString()).Returns(Path.Combine(FakeBatchValue.ExchangeSetMediaPath, "B2"));
+            A.CallTo(() => baseDir2.ToString()).Returns(Path.Combine(FakeBatchValue.LargeExchangeSetMediaPath5, "B2"));
             var baseDir3 = A.Fake<IDirectoryInfo>();
             A.CallTo(() => baseDir3.Name).Returns("Not a base directory");
-            A.CallTo(() => baseDir3.ToString()).Returns(Path.Combine(FakeBatchValue.ExchangeSetMediaPath, "Not a base directory"));
+            A.CallTo(() => baseDir3.ToString()).Returns(Path.Combine(FakeBatchValue.LargeExchangeSetMediaPath5, "Not a base directory"));
 
             // Base directories at exchangeSetPath
-            A.CallTo(() => _fakeFileSystemHelper.GetDirectoryInfo(FakeBatchValue.ExchangeSetMediaPath)).Returns([baseDir1, baseDir2, baseDir3]);
+            A.CallTo(() => _fakeFileSystemHelper.GetDirectoryInfo(FakeBatchValue.LargeExchangeSetMediaPath5)).Returns([baseDir1, baseDir2, baseDir3]);
 
             // ENC_ROOT folders under each base
             var encRoot1 = Path.Combine(baseDir1.ToString(), FakeBatchValue.EncRoot);
@@ -209,10 +209,10 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.FileBuilders
                 A<List<FulfilmentDataResponse>>.That.Matches(l => l.Count == 1 && l.Single().ProductName.StartsWith("DE")),
                 salesCatalogueDataResponse, salesCatalogueProductResponse)).Returns(secondResponse);
 
-            var result = await _fileBuilder.CreateLargeMediaExchangesetCatalogFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetMediaPath, FakeBatchValue.CorrelationId, listFulfilmentData, salesCatalogueDataResponse, salesCatalogueProductResponse);
+            var result = await _fileBuilder.CreateLargeMediaExchangesetCatalogFile(FakeBatchValue.BatchId, FakeBatchValue.LargeExchangeSetMediaPath5, FakeBatchValue.CorrelationId, listFulfilmentData, salesCatalogueDataResponse, salesCatalogueProductResponse);
 
             Assert.That(result, Is.EqualTo(secondResponse));
-            A.CallTo(() => _fakeFileSystemHelper.GetDirectoryInfo(FakeBatchValue.ExchangeSetMediaPath)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fakeFileSystemHelper.GetDirectoryInfo(FakeBatchValue.LargeExchangeSetMediaPath5)).MustHaveHappenedOnceExactly();
             A.CallTo(() => _fulfilmentAncillaryFiles.CreateLargeExchangeSetCatalogFile(
                 FakeBatchValue.BatchId, encRoot1, FakeBatchValue.CorrelationId,
                 A<List<FulfilmentDataResponse>>.That.Matches(l => l.Count == 2 && l.Any(p => p.ProductName.StartsWith("GB")) && l.Any(p => p.ProductName.StartsWith("FR"))),

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/Services/FulfilmentAncillaryFilesTest.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/Services/FulfilmentAncillaryFilesTest.cs
@@ -312,17 +312,17 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
         [Test]
         public void WhenInvalidCreateMediaFileRequest_ThenReturnFulfilmentException()
         {
-            A.CallTo(() => fakeFileSystemHelper.CreateFileContent(FakeBatchValue.ExchangeSetMediaFilePath, A<string>.Ignored)).Returns(true);
-            A.CallTo(() => fakeFileSystemHelper.CheckFileExists(FakeBatchValue.ExchangeSetMediaFilePath)).Returns(false);
+            A.CallTo(() => fakeFileSystemHelper.CreateFileContent(FakeBatchValue.LargeExchangeSetMediaFilePath5, A<string>.Ignored)).Returns(true);
+            A.CallTo(() => fakeFileSystemHelper.CheckFileExists(FakeBatchValue.LargeExchangeSetMediaFilePath5)).Returns(false);
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(FulfilmentExceptionMessage),
-                async delegate { await fulfilmentAncillaryFiles.CreateMediaFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetMediaPath, FakeBatchValue.CorrelationId, FakeBatchValue.ExchangeSetMediaBaseNumber); });
+                async delegate { await fulfilmentAncillaryFiles.CreateMediaFile(FakeBatchValue.BatchId, FakeBatchValue.LargeExchangeSetMediaPath5, FakeBatchValue.CorrelationId, FakeBatchValue.MediaBaseNumber5); });
         }
 
         [Test]
         public async Task WhenInvalidCreateMediaFileRequest_WithEmptyPath_ThenReturnFalseResponse()
         {
-            var response = await fulfilmentAncillaryFiles.CreateMediaFile(FakeBatchValue.BatchId, string.Empty, FakeBatchValue.CorrelationId, FakeBatchValue.ExchangeSetMediaBaseNumber);
+            var response = await fulfilmentAncillaryFiles.CreateMediaFile(FakeBatchValue.BatchId, string.Empty, FakeBatchValue.CorrelationId, FakeBatchValue.MediaBaseNumber5);
 
             Assert.That(response, Is.False);
         }
@@ -330,8 +330,8 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
         [Test]
         public async Task WhenValidCreateMediaFileRequest_ThenReturnTrueResponse()
         {
-            var baseFolderPath1 = Path.Combine(FakeBatchValue.ExchangeSetMediaPath, "B1");
-            var baseFolderPath2 = Path.Combine(FakeBatchValue.ExchangeSetMediaPath, "B2");
+            var baseFolderPath1 = Path.Combine(FakeBatchValue.LargeExchangeSetMediaPath5, "B1");
+            var baseFolderPath2 = Path.Combine(FakeBatchValue.LargeExchangeSetMediaPath5, "B2");
             var baseEncFolderPath1 = Path.Combine(baseFolderPath1, FakeBatchValue.EncRoot);
             var baseEncFolderPath2 = Path.Combine(baseFolderPath2, FakeBatchValue.EncRoot);
             var baseFolder1 = A.Fake<IDirectoryInfo>();
@@ -343,21 +343,21 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
             IDirectoryInfo[] baseFolders = [baseFolder1, baseFolder2];
             string[] subdirectoryPaths1 = [Path.Combine(baseEncFolderPath1, "GB"), Path.Combine(baseEncFolderPath1, "FR")];
             string[] subdirectoryPaths2 = [Path.Combine(baseEncFolderPath2, "DE")];
-            A.CallTo(() => fakeFileSystemHelper.GetDirectoryInfo(FakeBatchValue.ExchangeSetMediaPath)).Returns(baseFolders);
+            A.CallTo(() => fakeFileSystemHelper.GetDirectoryInfo(FakeBatchValue.LargeExchangeSetMediaPath5)).Returns(baseFolders);
             A.CallTo(() => fakeFileSystemHelper.GetDirectories(baseEncFolderPath1)).Returns(subdirectoryPaths1);
             A.CallTo(() => fakeFileSystemHelper.GetDirectories(baseEncFolderPath2)).Returns(subdirectoryPaths2);
-            A.CallTo(() => fakeFileSystemHelper.CreateFileContent(FakeBatchValue.ExchangeSetMediaFilePath, A<string>.Ignored)).Returns(true);
-            A.CallTo(() => fakeFileSystemHelper.CheckFileExists(FakeBatchValue.ExchangeSetMediaFilePath)).Returns(true);
+            A.CallTo(() => fakeFileSystemHelper.CreateFileContent(FakeBatchValue.LargeExchangeSetMediaFilePath5, A<string>.Ignored)).Returns(true);
+            A.CallTo(() => fakeFileSystemHelper.CheckFileExists(FakeBatchValue.LargeExchangeSetMediaFilePath5)).Returns(true);
 
-            var response = await fulfilmentAncillaryFiles.CreateMediaFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetMediaPath, FakeBatchValue.CorrelationId, FakeBatchValue.ExchangeSetMediaBaseNumber);
+            var response = await fulfilmentAncillaryFiles.CreateMediaFile(FakeBatchValue.BatchId, FakeBatchValue.LargeExchangeSetMediaPath5, FakeBatchValue.CorrelationId, FakeBatchValue.MediaBaseNumber5);
 
             Assert.That(response, Is.True);
-            A.CallTo(() => fakeFileSystemHelper.CheckAndCreateFolder(FakeBatchValue.ExchangeSetMediaPath)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => fakeFileSystemHelper.GetDirectoryInfo(FakeBatchValue.ExchangeSetMediaPath)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => fakeFileSystemHelper.CheckAndCreateFolder(FakeBatchValue.LargeExchangeSetMediaPath5)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => fakeFileSystemHelper.GetDirectoryInfo(FakeBatchValue.LargeExchangeSetMediaPath5)).MustHaveHappenedOnceExactly();
             A.CallTo(() => fakeFileSystemHelper.GetDirectories(baseEncFolderPath1)).MustHaveHappenedOnceExactly();
             A.CallTo(() => fakeFileSystemHelper.GetDirectories(baseEncFolderPath2)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => fakeFileSystemHelper.CreateFileContent(FakeBatchValue.ExchangeSetMediaFilePath, A<string>.Ignored)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => fakeFileSystemHelper.CheckFileExists(FakeBatchValue.ExchangeSetMediaFilePath)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => fakeFileSystemHelper.CreateFileContent(FakeBatchValue.LargeExchangeSetMediaFilePath5, A<string>.Ignored)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => fakeFileSystemHelper.CheckFileExists(FakeBatchValue.LargeExchangeSetMediaFilePath5)).MustHaveHappenedOnceExactly();
         }
 
         #endregion
@@ -367,7 +367,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
         [Test]
         public void WhenInvalidCreateLargeMediaSerialEncFileRequest_ThenReturnFulfilmentException()
         {
-            var baseFolderPath = Path.Combine(FakeBatchValue.ExchangeSetMediaPath, "B1");
+            var baseFolderPath = Path.Combine(FakeBatchValue.LargeExchangeSetMediaPath5, "B1");
             A.CallTo(() => fakeFileSystemHelper.CheckAndCreateFolder(A<string>.Ignored));
             A.CallTo(() => fakeFileSystemHelper.CreateFileContent(A<string>.Ignored, A<string>.Ignored)).Returns(true);
             A.CallTo(() => fakeFileSystemHelper.CheckFileExists(A<string>.Ignored)).Returns(false);
@@ -387,7 +387,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
         [Test]
         public async Task WhenValidCreateLargeMediaSerialEncFileRequest_ThenReturnTrueResponse()
         {
-            var baseFolderPath = Path.Combine(FakeBatchValue.ExchangeSetMediaPath, "B1");
+            var baseFolderPath = Path.Combine(FakeBatchValue.LargeExchangeSetMediaPath5, "B1");
             var serialFilePath = Path.Combine(baseFolderPath, FakeBatchValue.SerialFileName);
             var baseNumber = "1";
             A.CallTo(() => fakeFileSystemHelper.CreateFileContent(serialFilePath, A<string>.Ignored)).Returns(true);
@@ -408,7 +408,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
         [Test]
         public async Task WhenValidCreateLargeExchangeSetCatalogFileRequest_ThenReturnTrueReponse()
         {
-            var b1Path = Path.Combine(FakeBatchValue.ExchangeSetMediaPath, "B1");
+            var b1Path = Path.Combine(FakeBatchValue.LargeExchangeSetMediaPath5, "B1");
             var exchangeSetRootPath = Path.Combine(b1Path, FakeBatchValue.EncRoot);
             var readMeFileName = Path.Combine(exchangeSetRootPath, FakeBatchValue.ReadMeFileName);
             var outputFileName = Path.Combine(exchangeSetRootPath, FakeBatchValue.CatalogFileName);
@@ -421,7 +421,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
                 new() { BatchId = "63d38bde-5191-4a59-82d5-aa22ca1cc6dc", EditionNumber = 10, ProductName = "10000003", UpdateNumber = 3, FileUri = new List<string> { "http://ffs-demo.azurewebsites.net" }, Files = GetFiles() }
             };
             var directoryInfo = A.Fake<IDirectoryInfo>();
-            A.CallTo(() => directoryInfo.Name).Returns($"M0{FakeBatchValue.ExchangeSetMediaBaseNumber}X02");
+            A.CallTo(() => directoryInfo.Name).Returns($"M0{FakeBatchValue.MediaBaseNumber5}X02");
             A.CallTo(() => fakeFileSystemHelper.CheckFileExists(readMeFileName)).Returns(true);
             A.CallTo(() => fakeFileSystemHelper.CheckFileExists(outputFileName)).Returns(true);
             A.CallTo(() => fakeFileSystemHelper.ReadAllBytes(A<string>.Ignored)).Returns(byteContent);
@@ -450,7 +450,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
         [Test]
         public void WhenInvalidCreateLargeExchangeSetCatalogFileRequest_ThenReturnFulfilmentException()
         {
-            var b1Path = Path.Combine(FakeBatchValue.ExchangeSetMediaPath, "B1");
+            var b1Path = Path.Combine(FakeBatchValue.LargeExchangeSetMediaPath5, "B1");
             var exchangeSetRootPath = Path.Combine(b1Path, FakeBatchValue.EncRoot);
             var readMeFileName = Path.Combine(exchangeSetRootPath, FakeBatchValue.ReadMeFileName);
             var outputFileName = Path.Combine(exchangeSetRootPath, FakeBatchValue.CatalogFileName);
@@ -463,7 +463,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
                 new() { BatchId = "63d38bde-5191-4a59-82d5-aa22ca1cc6dc", EditionNumber = 10, ProductName = "10000003", UpdateNumber = 3, FileUri = new List<string> { "http://ffs-demo.azurewebsites.net" }, Files = GetFiles() }
             };
             var directoryInfo = A.Fake<IDirectoryInfo>();
-            A.CallTo(() => directoryInfo.Name).Returns($"M0{FakeBatchValue.ExchangeSetMediaBaseNumber}X02");
+            A.CallTo(() => directoryInfo.Name).Returns($"M0{FakeBatchValue.MediaBaseNumber5}X02");
             A.CallTo(() => fakeFileSystemHelper.CheckFileExists(readMeFileName)).Returns(true);
             A.CallTo(() => fakeFileSystemHelper.CheckFileExists(outputFileName)).Returns(false);
             A.CallTo(() => fakeFileSystemHelper.ReadAllBytes(A<string>.Ignored)).Returns(byteContent);
@@ -478,7 +478,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
         [Test]
         public void WhenNullCreateLargeExchangeSetCatalogFileRequest_ThenReturnFulfilmentException()
         {
-            var b1Path = Path.Combine(FakeBatchValue.ExchangeSetMediaPath, "B1");
+            var b1Path = Path.Combine(FakeBatchValue.LargeExchangeSetMediaPath5, "B1");
             var exchangeSetRootPath = Path.Combine(b1Path, FakeBatchValue.EncRoot);
             var readMeFileName = Path.Combine(exchangeSetRootPath, FakeBatchValue.ReadMeFileName);
             var outputFileName = Path.Combine(exchangeSetRootPath, FakeBatchValue.CatalogFileName);
@@ -503,28 +503,28 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
         public void WhenInvalidCreateEncUpdateCsvFileRequest_ThenReturnFulfilmentException()
         {
             var textWriter = A.Fake<TextWriter>();
-            A.CallTo(() => fakeFileSystemHelper.WriteStream(FakeBatchValue.UpdateListFilePath)).Returns(textWriter);
-            A.CallTo(() => fakeFileSystemHelper.CheckFileExists(FakeBatchValue.UpdateListFilePath)).Returns(false);
+            A.CallTo(() => fakeFileSystemHelper.WriteStream(FakeBatchValue.UpdateListFilePath5)).Returns(textWriter);
+            A.CallTo(() => fakeFileSystemHelper.CheckFileExists(FakeBatchValue.UpdateListFilePath5)).Returns(false);
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(FulfilmentExceptionMessage),
-                async delegate { await fulfilmentAncillaryFiles.CreateEncUpdateCsv(GetSalesCatalogueDataResponse(), FakeBatchValue.ExchangeSetMediaInfoPath, FakeBatchValue.BatchId, FakeBatchValue.CorrelationId); });
+                async delegate { await fulfilmentAncillaryFiles.CreateEncUpdateCsv(GetSalesCatalogueDataResponse(), FakeBatchValue.LargeExchangeSetMediaInfoPath5, FakeBatchValue.BatchId, FakeBatchValue.CorrelationId); });
 
-            A.CallTo(() => fakeFileSystemHelper.WriteStream(FakeBatchValue.UpdateListFilePath)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => fakeFileSystemHelper.CheckFileExists(FakeBatchValue.UpdateListFilePath)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => fakeFileSystemHelper.WriteStream(FakeBatchValue.UpdateListFilePath5)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => fakeFileSystemHelper.CheckFileExists(FakeBatchValue.UpdateListFilePath5)).MustHaveHappenedOnceExactly();
         }
 
         [Test]
         public async Task WhenValidCreateEncUpdateCsvFileRequest_ThenReturnTrueResponse()
         {
             var textWriter = A.Fake<TextWriter>();
-            A.CallTo(() => fakeFileSystemHelper.WriteStream(FakeBatchValue.UpdateListFilePath)).Returns(textWriter);
-            A.CallTo(() => fakeFileSystemHelper.CheckFileExists(FakeBatchValue.UpdateListFilePath)).Returns(true);
+            A.CallTo(() => fakeFileSystemHelper.WriteStream(FakeBatchValue.UpdateListFilePath5)).Returns(textWriter);
+            A.CallTo(() => fakeFileSystemHelper.CheckFileExists(FakeBatchValue.UpdateListFilePath5)).Returns(true);
 
-            var response = await fulfilmentAncillaryFiles.CreateEncUpdateCsv(GetSalesCatalogueDataResponse(), FakeBatchValue.ExchangeSetMediaInfoPath, FakeBatchValue.BatchId, FakeBatchValue.CorrelationId);
+            var response = await fulfilmentAncillaryFiles.CreateEncUpdateCsv(GetSalesCatalogueDataResponse(), FakeBatchValue.LargeExchangeSetMediaInfoPath5, FakeBatchValue.BatchId, FakeBatchValue.CorrelationId);
 
             Assert.That(response, Is.True);
-            A.CallTo(() => fakeFileSystemHelper.WriteStream(FakeBatchValue.UpdateListFilePath)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => fakeFileSystemHelper.CheckFileExists(FakeBatchValue.UpdateListFilePath)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => fakeFileSystemHelper.WriteStream(FakeBatchValue.UpdateListFilePath5)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => fakeFileSystemHelper.CheckFileExists(FakeBatchValue.UpdateListFilePath5)).MustHaveHappenedOnceExactly();
         }
 
         #endregion

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/Services/FulfilmentFileShareServiceTest.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/Services/FulfilmentFileShareServiceTest.cs
@@ -234,12 +234,12 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
         public async Task WhenRequestDownloadFolderDetails_ThenReturnsBoolForFileIsDownloaded(bool isFileDownloaded)
         {
             var batchFiles = new List<BatchFile>();
-            A.CallTo(() => fakefileShareService.DownloadFolderDetails(FakeBatchValue.BatchId, FakeBatchValue.CorrelationId, batchFiles, FakeBatchValue.ExchangeSetMediaInfoPath)).Returns(isFileDownloaded);
+            A.CallTo(() => fakefileShareService.DownloadFolderDetails(FakeBatchValue.BatchId, FakeBatchValue.CorrelationId, batchFiles, FakeBatchValue.LargeExchangeSetMediaInfoPath5)).Returns(isFileDownloaded);
 
-            var result = await fulfilmentFileShareService.DownloadFolderDetails(FakeBatchValue.BatchId, FakeBatchValue.CorrelationId, batchFiles, FakeBatchValue.ExchangeSetMediaInfoPath);
+            var result = await fulfilmentFileShareService.DownloadFolderDetails(FakeBatchValue.BatchId, FakeBatchValue.CorrelationId, batchFiles, FakeBatchValue.LargeExchangeSetMediaInfoPath5);
 
             Assert.That(result, Is.EqualTo(isFileDownloaded));
-            A.CallTo(() => fakefileShareService.DownloadFolderDetails(FakeBatchValue.BatchId, FakeBatchValue.CorrelationId, batchFiles, FakeBatchValue.ExchangeSetMediaInfoPath)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => fakefileShareService.DownloadFolderDetails(FakeBatchValue.BatchId, FakeBatchValue.CorrelationId, batchFiles, FakeBatchValue.LargeExchangeSetMediaInfoPath5)).MustHaveHappenedOnceExactly();
         }
 
         #endregion DownloadFolderDetails

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/TestHelper/FakeBatchValue.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/TestHelper/FakeBatchValue.cs
@@ -32,19 +32,23 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.TestHelper
         /// <summary>
         /// 5
         /// </summary>
-        public const string ExchangeSetMediaBaseNumber = "5";
+        public const string MediaBaseNumber5 = "5";
         /// <summary>
         /// 6
         /// </summary>
-        public const string LastExchangeSetMediaBaseNumber = "6";
+        public const string MediaBaseNumber6 = "6";
         /// <summary>
         /// M05X02
         /// </summary>
-        public const string LargeExchangeSetFolderName = $"M0{ExchangeSetMediaBaseNumber}X02";
+        public const string LargeExchangeSetFolderName5 = $"M0{MediaBaseNumber5}X02";
+        /// <summary>
+        /// M0{0}X02
+        /// </summary>
+        public const string LargeExchangeSetFolderNamePattern = "M0{0}X02";
         /// <summary>
         /// M06X02
         /// </summary>
-        public const string LastLargeExchangeSetFolderName = $"M0{LastExchangeSetMediaBaseNumber}X02";
+        public const string LargeExchangeSetFolderName6 = $"M0{MediaBaseNumber6}X02";
         /// <summary>
         /// ENC_ROOT
         /// </summary>
@@ -101,11 +105,31 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.TestHelper
         /// ENC Update List.csv
         /// </summary>
         public const string UpdateListFileName = "ENC Update List.csv";
+        /// <summary>
+        /// ADDS-S57
+        /// </summary>
+        public const string S57BusinessUnit = "ADDS-S57";
+        /// <summary>
+        /// ADDS-S63
+        /// </summary>
+        public const string S63BusinessUnit = "ADDS";
+        /// <summary>
+        /// ADDS-S63
+        /// </summary>
+        public const string CurrentUtcDate = "25SEP2025";
+        /// <summary>
+        /// GB800001
+        /// </summary>
+        public const string AioCells = "GB800001";
 
+        /// <summary>
+        /// C:\HOME
+        /// </summary>
+        public const string HomeDirectoryPath = @"C:\HOME";
         /// <summary>
         /// C:\HOME\25SEP2025\7b4cdf10-adfa-4ed6-b2fe-d1543d8b7272
         /// </summary>
-        public const string BatchPath = $@"C:\HOME\25SEP2025\{BatchId}";
+        public const string BatchPath = $@"{HomeDirectoryPath}\{CurrentUtcDate}\{BatchId}";
         /// <summary>
         /// C:\HOME\25SEP2025\7b4cdf10-adfa-4ed6-b2fe-d1543d8b7272\V01X01
         /// </summary>
@@ -121,23 +145,39 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.TestHelper
         /// <summary>
         /// C:\HOME\25SEP2025\7b4cdf10-adfa-4ed6-b2fe-d1543d8b7272\M05X02
         /// </summary>
-        public const string ExchangeSetMediaPath = $@"{BatchPath}\{LargeExchangeSetFolderName}";
+        public const string LargeExchangeSetMediaPath5 = $@"{BatchPath}\{LargeExchangeSetFolderName5}";
         /// <summary>
         /// C:\HOME\25SEP2025\7b4cdf10-adfa-4ed6-b2fe-d1543d8b7272\M06X02
         /// </summary>
-        public const string LastExchangeSetMediaPath = $@"{BatchPath}\{LastLargeExchangeSetFolderName}";
+        public const string LargeExchangeSetMediaPath6 = $@"{BatchPath}\{LargeExchangeSetFolderName6}";
         /// <summary>
         /// C:\HOME\25SEP2025\7b4cdf10-adfa-4ed6-b2fe-d1543d8b7272\M05X02\INFO
         /// </summary>
-        public const string ExchangeSetMediaInfoPath = $@"{ExchangeSetMediaPath}\{Info}";
+        public const string LargeExchangeSetMediaInfoPath5 = $@"{LargeExchangeSetMediaPath5}\{Info}";
+        /// <summary>
+        /// C:\HOME\25SEP2025\7b4cdf10-adfa-4ed6-b2fe-d1543d8b7272\M06X02\INFO
+        /// </summary>
+        public const string LargeExchangeSetMediaInfoPath6 = $@"{LargeExchangeSetMediaPath6}\{Info}";
+        /// <summary>
+        /// C:\HOME\25SEP2025\7b4cdf10-adfa-4ed6-b2fe-d1543d8b7272\M05X02\INFO\ADC
+        /// </summary>
+        public const string LargeExchangeSetMediaInfoAdcPath5 = $@"{LargeExchangeSetMediaInfoPath5}\{Adc}";
+        /// <summary>
+        /// C:\HOME\25SEP2025\7b4cdf10-adfa-4ed6-b2fe-d1543d8b7272\M06X02\INFO\ADC
+        /// </summary>
+        public const string LargeExchangeSetMediaInfoAdcPath6 = $@"{LargeExchangeSetMediaInfoPath6}\{Adc}";
         /// <summary>
         /// C:\HOME\25SEP2025\7b4cdf10-adfa-4ed6-b2fe-d1543d8b7272\M05X02\INFO\ENC Update List.csv
         /// </summary>
-        public const string UpdateListFilePath = $@"{ExchangeSetMediaInfoPath}\{UpdateListFileName}";
+        public const string UpdateListFilePath5 = $@"{LargeExchangeSetMediaInfoPath5}\{UpdateListFileName}";
         /// <summary>
         /// C:\HOME\25SEP2025\7b4cdf10-adfa-4ed6-b2fe-d1543d8b7272\M05X02\MEDIA.TXT
         /// </summary>
-        public const string ExchangeSetMediaFilePath = $@"{ExchangeSetMediaPath}\{MediaFileName}";
+        public const string LargeExchangeSetMediaFilePath5 = $@"{LargeExchangeSetMediaPath5}\{MediaFileName}";
+        /// <summary>
+        /// C:\HOME\25SEP2025\7b4cdf10-adfa-4ed6-b2fe-d1543d8b7272\M0{0}X02\{1}\ENC_ROOT
+        /// </summary>
+        public const string LargeExchangeSetEncRootPattern = $@"{BatchPath}\{LargeExchangeSetFolderNamePattern}\{{1}}\{EncRoot}";
         /// <summary>
         /// C:\HOME\25SEP2025\7b4cdf10-adfa-4ed6-b2fe-d1543d8b7272\V01X01\SERIAL.ENC
         /// </summary>
@@ -211,8 +251,8 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.TestHelper
                 PublicBaseUrl = "https://fss-api-public.azurewebsites.net",
                 ReadMeFileName = ReadMeFileName,
                 ResourceId = "9dd69e65-a953-4a94-a624-c26e6fb33379",
-                S57BusinessUnit = "ADDS-S57",
-                S63BusinessUnit = "ADDS",
+                S57BusinessUnit = S57BusinessUnit,
+                S63BusinessUnit = S63BusinessUnit,
                 SerialAioFileName = SerialAioFileName,
                 SerialFileName = SerialFileName,
                 Start = 0,


### PR DESCRIPTION
#### PR Classification
Code cleanup and test enhancement.

#### PR Summary
This pull request enhances test coverage and refactors the codebase to align with a new folder structure and naming conventions, improving maintainability and reliability. It introduces new constants, updates test cases, and ensures consistency across files.
- **ExchangeSetBuilderTest.cs**: Added new test cases for AIO, standard, and large media exchange sets; introduced helper methods for test data generation.
- **FileBuilderTest.cs**: Refactored to use new constants (`LargeExchangeSetMediaPath5`, `LargeExchangeSetFolderNamePattern`) and updated test logic for large exchange sets.
- **FulfilmentAncillaryFilesTest.cs**: Updated file paths and folder names; enhanced validation for media file and catalog file creation.
- **FulfilmentFileShareServiceTest.cs**: Updated test cases to use `LargeExchangeSetMediaInfoPath5` for folder details validation.
- **FakeBatchValue.cs**: Introduced new constants for folder paths, patterns, and business units; refactored existing constants for consistency.
