### PR TITLE
Remove QA environment references and deployment stage

### DIFF
--- a/Deployment/src/Modules/APIM/variables.tf
+++ b/Deployment/src/Modules/APIM/variables.tf
@@ -67,7 +67,6 @@ variable "env_suffix" {
   type = map(string)
   default = {
     "dev"         = "Dev"
-    "qa"          = "QA"
     "vne"         = "VNE"
     "vni"         = "VNI"
     "iat"         = "IAT"

--- a/Deployment/src/variables.tf
+++ b/Deployment/src/variables.tf
@@ -19,7 +19,7 @@ locals {
     SERVICE_OWNER    = "Robin Chapman"
     RESPONSIBLE_TEAM = "Abzu"
     CALLOUT_TEAM     = "On-Call_N/A"
-    COST_CENTRE      = local.env_name == "dev" || local.env_name == "qa" || local.env_name == "prod" ? "A.008.02" : "A.011.08"
+    COST_CENTRE      = local.env_name == "dev" || local.env_name == "prod" ? "A.008.02" : "A.011.08"
   }
   config_data = jsondecode(file("${path.module}/appsettings.json"))
   # These names should match those used in AzureWebJobsHealthCheckService in UKHO.ExchangeSetService.Common.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -423,27 +423,3 @@ stages:
           ContinueEvenIfResourcesAreGettingDestroyed: ${{ parameters.ContinueEvenIfResourcesAreGettingDestroyed }}
           AzureSubscription: "Exchange-Set-Service-vNext-E2E-A.011.08"
           Container: ${{variables.Container}}
-
-  - stage: QAdeploy
-    dependsOn: 
-    - Devdeploy
-    displayName: QA Deploy (inc terraform, webapp deploy)
-    condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')))
-    jobs:
-      - template: Deployment/templates/app-deploy.yml
-        parameters:
-          Environment: "qa"
-          ContinueEvenIfResourcesAreGettingDestroyed: ${{ parameters.ContinueEvenIfResourcesAreGettingDestroyed }}
-          AzureSubscription: "Exchange-Set-Service-QA-A-008-02"
-          Container: ${{variables.Container}} 
-
-      - ${{ if eq(parameters.skipDeploymentOfUIInstance, false) }}:
-        - template: Deployment/templates/app-deploy.yml
-          parameters:
-            Environment: "qa"
-            ContinueEvenIfResourcesAreGettingDestroyed: ${{ parameters.ContinueEvenIfResourcesAreGettingDestroyed }}
-            AzureSubscription: "Exchange-Set-Service-QA-A-008-02"
-            Container: ${{variables.Container}} 
-            RunTests: false
-            pathSuffix: "-v2"
-            v2Modifier: "2"


### PR DESCRIPTION
The `env_suffix` variable in `variables.tf` was updated to remove the "qa" environment mapping. The `COST_CENTRE` logic was adjusted to exclude "qa" from the condition, leaving only "dev" and "prod" mapped to "A.008.02". Additionally, the `QAdeploy` stage was removed from `azure-pipelines.yml`, including its dependencies, display name, condition, and associated jobs/templates.