### PR TITLE
Update NUnit packages

### DIFF
--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/Helper/FileContentHelper.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/Helper/FileContentHelper.cs
@@ -471,12 +471,12 @@ namespace UKHO.ExchangeSetService.API.FunctionalTests.Helper
             var year = DateTime.UtcNow.Year.ToString().Substring(DateTime.UtcNow.Year.ToString().Length - 2);
             var currentDate = DateTime.UtcNow.ToString("yyyyMMdd");
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That($"GBWK{weekNumber}-{year}", Is.EqualTo(dataServerAndWeek), $"Incorrect weeknumber and year is returned 'GBWK{weekNumber}-{year}', instead of the expected {dataServerAndWeek}.");
                 Assert.That($"{currentDate}{cdType}", Is.EqualTo(dateAndCdType), $"Incorrect date is returned '{currentDate}UPDATE', instead of the expected {dateAndCdType}.");
                 Assert.That(formatVersionAndExchangeSetNumber, Does.StartWith("02.00"), $"Expected format version {formatVersionAndExchangeSetNumber}");
-            });
+            }
         }
 
         public static async Task<bool> WaitForContainerAsync(BlobServiceClient blobServiceClient, string containerName, int maxAttempts, int delayInMilliSeconds)

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/UKHO.ExchangeSetService.API.FunctionalTests.csproj
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.FunctionalTests/UKHO.ExchangeSetService.API.FunctionalTests.csproj
@@ -19,12 +19,12 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.16" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.16" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.84.1" />
-    <PackageReference Include="NUnit" Version="4.5.1" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.12.0">
+    <PackageReference Include="NUnit" Version="4.6.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="System.Text.Json" Version="10.0.8" />
   </ItemGroup>

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Controllers/EssWebhookControllerTests.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Controllers/EssWebhookControllerTests.cs
@@ -64,11 +64,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
               && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2)!.ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Completed processing the Options request for the New Files Published event webhook for WebHook-Request-Origin:{webhookRequestOrigin}").MustHaveHappenedOnceExactly();
 
             Assert.That(responseHeaders, Has.Count.EqualTo(2));
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(responseHeaders["WebHook-Allowed-Rate"].ToString(), Is.EqualTo("*"));
                 Assert.That(responseHeaders["WebHook-Allowed-Origin"].ToString(), Is.EqualTo("test.com"));
-            });
+            }
         }
 
         [Test]

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Controllers/ProductBuilderControllerTests.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Controllers/ProductBuilderControllerTests.cs
@@ -105,11 +105,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
             var result = (BadRequestObjectResult)await controller.PostProductIdentifiers(productIdentifiers, callbackUri, exchangeSetStandard.ToString(), layout.ToString());
             var errors = (ErrorDescription)result.Value;
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.StatusCode, Is.EqualTo(400));
                 Assert.That(errors.Errors.Single().Description, Is.EqualTo("Product Identifiers cannot be null or empty."));
-            });
+            }
         }
 
         [Test]
@@ -134,11 +134,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
             var result = (BadRequestObjectResult)await controller.PostProductIdentifiers(null, null, exchangeSetStandard.ToString(), layout.ToString());
             var errors = (ErrorDescription)result.Value;
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.StatusCode, Is.EqualTo(400));
                 Assert.That(errors.Errors.Single().Description, Is.EqualTo("Either body is null or malformed."));
-            });
+            }
         }
 
         [Test]
@@ -166,12 +166,12 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
             var result = (BadRequestObjectResult)await controller.PostProductIdentifiers(productIdentifiers, callbackUri, exchangeSetStandard.ToString(), layout.ToString());
             var errors = (ErrorDescription)result.Value;
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.StatusCode, Is.EqualTo(400));
                 Assert.That(errors.Errors.Single().Source, Is.EqualTo("requestBody"));
                 Assert.That(errors.Errors.Single().Description, Is.EqualTo("Either body is null or malformed."));
-            });
+            }
         }
 
         [Test]
@@ -198,11 +198,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 
             var result = (ObjectResult)await controller.PostProductIdentifiers(productIdentifiers, callbackUri, exchangeSetStandard.ToString(), layout.ToString());
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(((InternalServerError)result.Value).Detail, Is.SameAs("Internal Server Error"));
                 Assert.That(result.StatusCode, Is.EqualTo(500));
-            });
+            }
         }
 
         [Test]
@@ -254,11 +254,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
             var result = (BadRequestObjectResult)await controller.PostProductIdentifiers(productIdentifiers, callbackUri, ExchangeSetStandard.s57.ToString(), ExchangeSetLayout.large.ToString());
             var errors = (ErrorDescription)result.Value;
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.StatusCode, Is.EqualTo(400));
                 Assert.That(errors.Errors.Single().Description, Is.EqualTo("The Exchange Set requested is very large and will not be created, please use a standard Exchange Set provided by the UKHO."));
-            });
+            }
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
                 && call.GetArgument<LogLevel>(0) == LogLevel.Error
@@ -290,11 +290,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 
             var result = (OkObjectResult)await controller.PostProductIdentifiers(productIdentifiers, callbackUri, ExchangeSetStandard.s63.ToString(), ExchangeSetLayout.large.ToString());
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.StatusCode, Is.EqualTo(200));
                 Assert.That(((ExchangeSetResponse)result.Value).ExchangeSetCellCount, Is.EqualTo(exchangeSetServiceResponse.ExchangeSetResponse.ExchangeSetCellCount));
-            });
+            }
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
                 && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -379,11 +379,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 
             var errors = (ErrorDescription)result.Value;
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.StatusCode, Is.EqualTo(400));
                 Assert.That(errors.Errors.Single().Description, Is.EqualTo("productName cannot be blank or null."));
-            });
+            }
         }
 
         [Test]
@@ -409,12 +409,12 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
             var result = (BadRequestObjectResult)await controller.PostproductBuilderByProductVersions(new List<ProductVersionRequest>(), "", exchangeSetStandard.ToString(), layout.ToString());
             var errors = (ErrorDescription)result.Value;
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.StatusCode, Is.EqualTo(400));
                 Assert.That(errors.Errors.Single().Source, Is.EqualTo("requestBody"));
                 Assert.That(errors.Errors.Single().Description, Is.EqualTo("Either body is null or malformed."));
-            });
+            }
         }
 
         [Test]
@@ -438,11 +438,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 
             var result = (ObjectResult)await controller.PostproductBuilderByProductVersions(new List<ProductVersionRequest> { new() { ProductName = "demo" } }, "", exchangeSetStandard.ToString(), layout.ToString());
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(((InternalServerError)result.Value).Detail, Is.SameAs("Internal Server Error"));
                 Assert.That(result.StatusCode, Is.EqualTo(500));
-            });
+            }
         }
 
         [Test]
@@ -488,11 +488,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
             var result = (BadRequestObjectResult)await controller.PostproductBuilderByProductVersions(new List<ProductVersionRequest> { new() { ProductName = "demo" } }, "", ExchangeSetStandard.s57.ToString(), ExchangeSetLayout.large.ToString());
             var errors = (ErrorDescription)result.Value;
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.StatusCode, Is.EqualTo(400));
                 Assert.That(errors.Errors.Single().Description, Is.EqualTo("The Exchange Set requested is very large and will not be created, please use a standard Exchange Set provided by the UKHO."));
-            });
+            }
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
                 && call.GetArgument<LogLevel>(0) == LogLevel.Error
@@ -521,11 +521,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 
             var result = (OkObjectResult)await controller.PostproductBuilderByProductVersions(new List<ProductVersionRequest> { new() { ProductName = "demo" } }, "", ExchangeSetStandard.s63.ToString(), ExchangeSetLayout.large.ToString());
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.StatusCode, Is.EqualTo(200));
                 Assert.That(((ExchangeSetResponse)result.Value).ExchangeSetCellCount, Is.EqualTo(exchangeSetServiceResponse.ExchangeSetResponse.ExchangeSetCellCount));
-            });
+            }
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
                 && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -603,12 +603,12 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
             var result = (BadRequestObjectResult)await controller.GetproductBuilderSinceDateTime(null, "https://www.abc.com", exchangeSetStandard.ToString(), layout.ToString());
             var errors = (ErrorDescription)result.Value;
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.StatusCode, Is.EqualTo(400));
                 Assert.That(errors.Errors.Single().Source, Is.EqualTo("sinceDateTime"));
                 Assert.That(errors.Errors.Single().Description, Is.EqualTo("Query parameter 'sinceDateTime' is required."));
-            });
+            }
         }
 
         [Test]
@@ -632,11 +632,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 
             var result = (ObjectResult)await controller.GetproductBuilderSinceDateTime("Wed, 21 Oct 2015 07:28:00 GMT", "https://www.abc.com", exchangeSetStandard.ToString(), layout.ToString());
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(((InternalServerError)result.Value).Detail, Is.SameAs("Internal Server Error"));
                 Assert.That(result.StatusCode, Is.EqualTo(500));
-            });
+            }
         }
 
         [Test]
@@ -682,11 +682,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
             var result = (BadRequestObjectResult)await controller.GetproductBuilderSinceDateTime("Wed, 21 Oct 2015 07:28:00 GMT", "https://www.abc.com", ExchangeSetStandard.s57.ToString(), ExchangeSetLayout.large.ToString());
             var errors = (ErrorDescription)result.Value;
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.StatusCode, Is.EqualTo(400));
                 Assert.That(errors.Errors.Single().Description, Is.EqualTo("The Exchange Set requested is very large and will not be created, please use a standard Exchange Set provided by the UKHO."));
-            });
+            }
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
                 && call.GetArgument<LogLevel>(0) == LogLevel.Error
@@ -715,11 +715,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 
             var result = (OkObjectResult)await controller.GetproductBuilderSinceDateTime("Wed, 21 Oct 2015 07:28:00 GMT", "https://www.abc.com", ExchangeSetStandard.s63.ToString(), ExchangeSetLayout.large.ToString());
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.StatusCode, Is.EqualTo(200));
                 Assert.That(((ExchangeSetResponse)result.Value).ExchangeSetCellCount, Is.EqualTo(exchangeSetServiceResponse.ExchangeSetResponse.ExchangeSetCellCount));
-            });
+            }
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
                 && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -758,11 +758,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 
             var result = (OkObjectResult)await controller.GetproductBuilderSinceDateTime("Wed, 21 Oct 2015 07:28:00 GMT", "https://www.abc.com", exchangeSetStandard.ToString(), layout.ToString());
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(((ExchangeSetResponse)result.Value).ExchangeSetCellCount, Is.EqualTo(exchangeSetServiceResponse.ExchangeSetResponse.ExchangeSetCellCount));
                 Assert.That(result.StatusCode, Is.EqualTo(200));
-            });
+            }
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
                 && call.GetArgument<LogLevel>(0) == LogLevel.Information

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Controllers/ProductDataControllerTests.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Controllers/ProductDataControllerTests.cs
@@ -115,11 +115,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 
             var result = (BadRequestObjectResult)await controller.PostProductIdentifiers(productIdentifiers, callbackUri, exchangeSetStandard.ToString().ToString());
             var errors = (ErrorDescription)result.Value;
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.StatusCode, Is.EqualTo(400));
                 Assert.That(errors.Errors.Single().Description, Is.EqualTo("Product Identifiers cannot be null or empty."));
-            });
+            }
         }
 
         [Test]
@@ -145,11 +145,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 
             var result = (BadRequestObjectResult)await controller.PostProductIdentifiers(null, null, exchangeSetStandard.ToString());
             var errors = (ErrorDescription)result.Value;
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.StatusCode, Is.EqualTo(400));
                 Assert.That(errors.Errors.Single().Description, Is.EqualTo("Either body is null or malformed."));
-            });
+            }
         }
 
         [Test]
@@ -178,12 +178,12 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 
             var result = (BadRequestObjectResult)await controller.PostProductIdentifiers(productIdentifiers, callbackUri, exchangeSetStandard.ToString());
             var errors = (ErrorDescription)result.Value;
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.StatusCode, Is.EqualTo(400));
                 Assert.That(errors.Errors.Single().Source, Is.EqualTo("requestBody"));
                 Assert.That(errors.Errors.Single().Description, Is.EqualTo("Either body is null or malformed."));
-            });
+            }
         }
 
         [Test]
@@ -211,11 +211,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
             string callbackUri = string.Empty;
 
             var result = (ObjectResult)await controller.PostProductIdentifiers(productIdentifiers, callbackUri, exchangeSetStandard.ToString());
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(((InternalServerError)result.Value).Detail, Is.SameAs("Internal Server Error"));
                 Assert.That(result.StatusCode, Is.EqualTo(500));
-            });
+            }
         }
 
         [Test]
@@ -269,11 +269,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
             var result = (BadRequestObjectResult)await controller.PostProductIdentifiers(productIdentifiers, callbackUri, ExchangeSetStandard.s57.ToString());
             var errors = (ErrorDescription)result.Value;
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.StatusCode, Is.EqualTo(400));
                 Assert.That(errors.Errors.Single().Description, Is.EqualTo("The Exchange Set requested is very large and will not be created, please use a standard Exchange Set provided by the UKHO."));
-            });
+            }
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Error
@@ -303,11 +303,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 
             var result = (OkObjectResult)await controller.PostProductIdentifiers(productIdentifiers, callbackUri, ExchangeSetStandard.s63.ToString());
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.StatusCode, Is.EqualTo(200));
                 Assert.That(((ExchangeSetResponse)result.Value).ExchangeSetCellCount, Is.EqualTo(exchangeSetServiceResponse.ExchangeSetResponse.ExchangeSetCellCount));
-            });
+            }
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -383,11 +383,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 
             var errors = (ErrorDescription)result.Value;
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.StatusCode, Is.EqualTo(400));
                 Assert.That(errors.Errors.Single().Description, Is.EqualTo("productName cannot be blank or null."));
-            });
+            }
         }
 
         [Test]
@@ -416,12 +416,12 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
             var result = (BadRequestObjectResult)await controller.PostProductDataByProductVersions(new List<ProductVersionRequest>(), "", exchangeSetStandard.ToString());
             var errors = (ErrorDescription)result.Value;
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.StatusCode, Is.EqualTo(400));
                 Assert.That(errors.Errors.Single().Source, Is.EqualTo("requestBody"));
                 Assert.That(errors.Errors.Single().Description, Is.EqualTo("Either body is null or malformed."));
-            });
+            }
         }
 
         [Test]
@@ -448,11 +448,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
             var result = (ObjectResult)await controller.PostProductDataByProductVersions(new List<ProductVersionRequest>()
                             { new ProductVersionRequest() { ProductName = "demo" } }, "", exchangeSetStandard.ToString());
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(((InternalServerError)result.Value).Detail, Is.SameAs("Internal Server Error"));
                 Assert.That(result.StatusCode, Is.EqualTo(500));
-            });
+            }
         }
 
         [Test]
@@ -502,11 +502,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
                             { new() { ProductName = "demo" } }, "", ExchangeSetStandard.s57.ToString());
             var errors = (ErrorDescription)result.Value;
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.StatusCode, Is.EqualTo(400));
                 Assert.That(errors.Errors.Single().Description, Is.EqualTo("The Exchange Set requested is very large and will not be created, please use a standard Exchange Set provided by the UKHO."));
-            });
+            }
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Error
@@ -534,11 +534,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
             var result = (OkObjectResult)await controller.PostProductDataByProductVersions(new List<ProductVersionRequest>()
                             { new() { ProductName = "demo" } }, "", ExchangeSetStandard.s63.ToString());
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.StatusCode, Is.EqualTo(200));
                 Assert.That(((ExchangeSetResponse)result.Value).ExchangeSetCellCount, Is.EqualTo(exchangeSetServiceResponse.ExchangeSetResponse.ExchangeSetCellCount));
-            });
+            }
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -609,12 +609,12 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
             var result = (BadRequestObjectResult)await controller.GetProductDataSinceDateTime(null, "https://www.abc.com", exchangeSetStandard.ToString());
             var errors = (ErrorDescription)result.Value;
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.StatusCode, Is.EqualTo(400));
                 Assert.That(errors.Errors.Single().Source, Is.EqualTo("sinceDateTime"));
                 Assert.That(errors.Errors.Single().Description, Is.EqualTo("Query parameter 'sinceDateTime' is required."));
-            });
+            }
         }
 
         [Test]
@@ -640,11 +640,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 
             var result = (ObjectResult)await controller.GetProductDataSinceDateTime("Wed, 21 Oct 2015 07:28:00 GMT", "https://www.abc.com", exchangeSetStandard.ToString());
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(((InternalServerError)result.Value).Detail, Is.SameAs("Internal Server Error"));
                 Assert.That(result.StatusCode, Is.EqualTo(500));
-            });
+            }
         }
 
         [Test]
@@ -692,11 +692,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
             var result = (BadRequestObjectResult)await controller.GetProductDataSinceDateTime("Wed, 21 Oct 2015 07:28:00 GMT", "https://www.abc.com", ExchangeSetStandard.s57.ToString());
             var errors = (ErrorDescription)result.Value;
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.StatusCode, Is.EqualTo(400));
                 Assert.That(errors.Errors.Single().Description, Is.EqualTo("The Exchange Set requested is very large and will not be created, please use a standard Exchange Set provided by the UKHO."));
-            });
+            }
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Error
@@ -723,11 +723,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 
             var result = (OkObjectResult)await controller.GetProductDataSinceDateTime("Wed, 21 Oct 2015 07:28:00 GMT", "https://www.abc.com", ExchangeSetStandard.s63.ToString());
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.StatusCode, Is.EqualTo(200));
                 Assert.That(((ExchangeSetResponse)result.Value).ExchangeSetCellCount, Is.EqualTo(exchangeSetServiceResponse.ExchangeSetResponse.ExchangeSetCellCount));
-            });
+            }
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -760,11 +760,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 
             var result = (OkObjectResult)await controller.GetProductDataSinceDateTime("Wed, 21 Oct 2015 07:28:00 GMT", "https://www.abc.com", exchangeSetStandard.ToString());
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(((ExchangeSetResponse)result.Value).ExchangeSetCellCount, Is.EqualTo(exchangeSetServiceResponse.ExchangeSetResponse.ExchangeSetCellCount));
                 Assert.That(result.StatusCode, Is.EqualTo(200));
-            });
+            }
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Controllers/ProductInformationControllerTests.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Controllers/ProductInformationControllerTests.cs
@@ -90,11 +90,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
             var result = (BadRequestObjectResult)await controller.PostProductIdentifiers(productIdentifiers);
 
             var errors = (ErrorDescription)result.Value;
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.StatusCode, Is.EqualTo(400));
                 Assert.That(errors.Errors.Single().Description, Is.EqualTo("Product Identifiers cannot be null or empty."));
-            });
+            }
         }
 
         [Test]
@@ -118,11 +118,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
 
             var result = (BadRequestObjectResult)await controller.PostProductIdentifiers(null);
             var errors = (ErrorDescription)result.Value;
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.StatusCode, Is.EqualTo(400));
                 Assert.That(errors.Errors.Single().Description, Is.EqualTo("Either body is null or malformed."));
-            });
+            }
         }
 
         [Test]
@@ -141,11 +141,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
             string[] productIdentifiers = new string[] { "GB123456", "GB160060", "AU334550" };
 
             var result = (ObjectResult)await controller.PostProductIdentifiers(productIdentifiers);
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(((InternalServerError)result.Value).Detail, Is.SameAs("Internal Server Error"));
                 Assert.That(result.StatusCode, Is.EqualTo(500));
-            });
+            }
         }
 
         #endregion PostProductIdentifiers
@@ -193,12 +193,12 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
             var result = (BadRequestObjectResult)await controller.GetProductInformationSinceDateTime("Fri, 8 Mar 2024");
             var errors = (ErrorDescription)result.Value;
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.StatusCode, Is.EqualTo(400));
                 Assert.That(errors.Errors.Single().Source, Is.EqualTo("sinceDateTime"));
                 Assert.That(errors.Errors.Single().Description, Is.EqualTo("Provided sinceDateTime is either invalid or invalid format, the valid format is 'RFC1123 format' (e.g. 'Wed, 21 Oct 2020 07:28:00 GMT')."));
-            });
+            }
         }
 
         [Test]
@@ -207,12 +207,12 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
             var result = (BadRequestObjectResult)await controller.GetProductInformationSinceDateTime(null);
             var errors = (ErrorDescription)result.Value;
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.StatusCode, Is.EqualTo(400));
                 Assert.That(errors.Errors.Single().Source, Is.EqualTo("sinceDateTime"));
                 Assert.That(errors.Errors.Single().Description, Is.EqualTo("Query parameter 'sinceDateTime' is required."));
-            });
+            }
         }
 
         [Test]
@@ -230,11 +230,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Controllers
                 .Returns(salesCatalogueResponse);
 
             var result = (ObjectResult)await controller.GetProductInformationSinceDateTime("Fri, 22 Mar 2024");
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(((InternalServerError)result.Value).Detail, Is.SameAs("Internal Server Error"));
                 Assert.That(result.StatusCode, Is.EqualTo(500));
-            });
+            }
         }
 
         #endregion GetScsResponsebySinceDateTime

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Filters/BespokeExchangeSetAuthorizationFilterAttributeTests.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Filters/BespokeExchangeSetAuthorizationFilterAttributeTests.cs
@@ -69,7 +69,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Filters
         [Test]
         public void WhenParameterIsNull_ThenConstructorThrowsArgumentNullException()
         {
-            var ex = Assert.Throws<ArgumentNullException>(() => new BespokeExchangeSetAuthorizationFilterAttribute(null, null, null, null));
+            var ex = Assert.Throws<ArgumentNullException>((Action)(() => new BespokeExchangeSetAuthorizationFilterAttribute(null, null, null, null)));
             Assert.That(ex.ParamName, Is.EqualTo("azureAdConfiguration"));
         }
 
@@ -86,11 +86,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Filters
 
             await bespokeFilterAttribute.OnActionExecutionAsync(actionExecutingContext, () => Task.FromResult(actionExecutedContext));
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(httpContext.Response.StatusCode, Is.EqualTo(StatusCodes.Status200OK));
                 Assert.That(actionExecutingContext.ActionArguments[ExchangeSetStandard], Is.EqualTo(Common.Models.Enums.ExchangeSetStandardForUnitTests.s63.ToString()));
-            });
+            }
         }
 
         [Test]
@@ -108,11 +108,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Filters
 
             await bespokeFilterAttribute.OnActionExecutionAsync(actionExecutingContext, () => Task.FromResult(actionExecutedContext));
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(httpContext.Response.StatusCode, Is.EqualTo(StatusCodes.Status200OK));
                 Assert.That(actionExecutingContext.ActionArguments[ExchangeSetStandard], Is.EqualTo(Common.Models.Enums.ExchangeSetStandardForUnitTests.s57.ToString()));
-            });
+            }
         }
 
         [Test]
@@ -130,11 +130,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Filters
 
             await bespokeFilterAttribute.OnActionExecutionAsync(actionExecutingContext, () => Task.FromResult(actionExecutedContext));
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(httpContext.Response.StatusCode, Is.EqualTo(StatusCodes.Status200OK));
                 Assert.That(actionExecutingContext.ActionArguments[ExchangeSetStandard], Is.EqualTo(Common.Models.Enums.ExchangeSetStandardForUnitTests.s63.ToString()));
-            });
+            }
         }
 
         [Test]
@@ -153,11 +153,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Filters
 
             await bespokeFilterAttribute.OnActionExecutionAsync(actionExecutingContext, () => Task.FromResult(actionExecutedContext));
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(httpContext.Response.StatusCode, Is.EqualTo(StatusCodes.Status200OK));
                 Assert.That(actionExecutingContext.ActionArguments[ExchangeSetStandard], Is.EqualTo(Common.Models.Enums.ExchangeSetStandardForUnitTests.s57.ToString()));
-            });
+            }
         }
 
         [Test]
@@ -239,11 +239,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Filters
 
             await bespokeFilterAttribute.OnActionExecutionAsync(actionExecutingContext, () => Task.FromResult(actionExecutedContext));
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(httpContext.Response.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
                 Assert.That(actionExecutingContext.ActionArguments[ExchangeSetStandard], Is.EqualTo(Common.Models.Enums.ExchangeSetStandardForUnitTests.s57.ToString()));
-            });
+            }
         }
 
         [Test]
@@ -290,11 +290,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Filters
             A.CallTo(() => fakeAzureAdB2CHelper.IsAzureB2CUser(A<AzureAdB2C>.Ignored, A<string>.Ignored)).Returns(true);
             await bespokeFilterAttribute.OnActionExecutionAsync(actionExecutingContext, () => Task.FromResult(actionExecutedContext));
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(httpContext.Response.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
                 Assert.That(actionExecutingContext.ActionArguments[ExchangeSetStandard], Is.EqualTo(Common.Models.Enums.ExchangeSetStandardForUnitTests.s57.ToString()));
-            });
+            }
         }
 
         [Test]
@@ -321,11 +321,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Filters
             A.CallTo(() => fakeAzureAdB2CHelper.IsAzureB2CUser(A<AzureAdB2C>.Ignored, A<string>.Ignored)).Returns(true);
             await bespokeFilterAttribute.OnActionExecutionAsync(actionExecutingContext, () => Task.FromResult(actionExecutedContext));
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(httpContext.Response.StatusCode, Is.EqualTo(StatusCodes.Status200OK));
                 Assert.That(actionExecutingContext.ActionArguments[ExchangeSetStandard], Is.EqualTo(Common.Models.Enums.ExchangeSetStandardForUnitTests.s57.ToString()));
-            });
+            }
         }
 
         [Test]
@@ -352,11 +352,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Filters
             A.CallTo(() => fakeAzureAdB2CHelper.IsAzureB2CUser(A<AzureAdB2C>.Ignored, A<string>.Ignored)).Returns(true);
             await bespokeFilterAttribute.OnActionExecutionAsync(actionExecutingContext, () => Task.FromResult(actionExecutedContext));
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(httpContext.Response.StatusCode, Is.EqualTo(StatusCodes.Status200OK));
                 Assert.That(actionExecutingContext.ActionArguments[ExchangeSetStandard], Is.EqualTo(Common.Models.Enums.ExchangeSetStandardForUnitTests.s57.ToString()));
-            });
+            }
         }
 
         [Test]
@@ -386,11 +386,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Filters
             A.CallTo(() => fakeAzureAdB2CHelper.IsAzureB2CUser(A<AzureAdB2C>.Ignored, A<string>.Ignored)).Returns(true);
             await bespokeFilterAttribute.OnActionExecutionAsync(actionExecutingContext, () => Task.FromResult(actionExecutedContext));
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(httpContext.Response.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
                 Assert.That(actionExecutingContext.ActionArguments[ExchangeSetStandard], Is.EqualTo(Common.Models.Enums.ExchangeSetStandardForUnitTests.s57.ToString()));
-            });
+            }
         }
 
         [Test]
@@ -416,11 +416,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Filters
             A.CallTo(() => fakeAzureAdB2CHelper.IsAzureB2CUser(A<AzureAdB2C>.Ignored, A<string>.Ignored)).Returns(true);
             await bespokeFilterAttribute.OnActionExecutionAsync(actionExecutingContext, () => Task.FromResult(actionExecutedContext));
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(httpContext.Response.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
                 Assert.That(actionExecutingContext.ActionArguments[ExchangeSetStandard], Is.EqualTo(Common.Models.Enums.ExchangeSetStandardForUnitTests.s57.ToString()));
-            });
+            }
         }
 
         [Test]
@@ -450,11 +450,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Filters
             A.CallTo(() => fakeAzureAdB2CHelper.IsAzureB2CUser(A<AzureAdB2C>.Ignored, A<string>.Ignored)).Returns(true);
             await bespokeFilterAttribute.OnActionExecutionAsync(actionExecutingContext, () => Task.FromResult(actionExecutedContext));
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(httpContext.Response.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
                 Assert.That(actionExecutingContext.ActionArguments[ExchangeSetStandard], Is.EqualTo(Common.Models.Enums.ExchangeSetStandardForUnitTests.s57.ToString()));
-            });
+            }
 
             A.CallTo(fakelogger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Error

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Services/EssWebhookServiceTests.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Services/EssWebhookServiceTests.cs
@@ -1,11 +1,4 @@
-﻿using Azure.Data.Tables;
-using FakeItEasy;
-using FluentValidation.Results;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
-using NUnit.Framework;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -13,6 +6,13 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Data.Tables;
+using FakeItEasy;
+using FluentValidation.Results;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using NUnit.Framework;
 using UKHO.ExchangeSetService.API.Services;
 using UKHO.ExchangeSetService.API.Validation;
 using UKHO.ExchangeSetService.Common.Configuration;
@@ -387,29 +387,29 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
         [Test]
         public void WhenParameterIsNull_ThenConstructorThrowsArgumentNullException()
         {
-            var nullAzureClientEx = Assert.Throws<ArgumentNullException>(() => new EssWebhookService(null, fakeAzureStorageService, fakeAzureBlobStorageClient, fakeEnterpriseEventCacheDataRequestValidator, fakeCacheConfiguration, fakeLogger, fakeEssFulfilmentStorageConfig, fakeFileShareServiceCache, fakeFileShareServiceClient, fakeFileSystemHelper, fakeFileShareServiceConfig, fakeAuthFssTokenProvider));
+            var nullAzureClientEx = Assert.Throws<ArgumentNullException>((Action)(() => new EssWebhookService(null, fakeAzureStorageService, fakeAzureBlobStorageClient, fakeEnterpriseEventCacheDataRequestValidator, fakeCacheConfiguration, fakeLogger, fakeEssFulfilmentStorageConfig, fakeFileShareServiceCache, fakeFileShareServiceClient, fakeFileSystemHelper, fakeFileShareServiceConfig, fakeAuthFssTokenProvider)));
             Assert.That(nullAzureClientEx!.Message, Is.EqualTo("Value cannot be null. (Parameter 'azureTableStorageClient')"));
-            var nullAzureServiceEx = Assert.Throws<ArgumentNullException>(() => new EssWebhookService(fakeAzureTableStorageClient, null, fakeAzureBlobStorageClient, fakeEnterpriseEventCacheDataRequestValidator, fakeCacheConfiguration, fakeLogger, fakeEssFulfilmentStorageConfig, fakeFileShareServiceCache, fakeFileShareServiceClient, fakeFileSystemHelper, fakeFileShareServiceConfig, fakeAuthFssTokenProvider));
+            var nullAzureServiceEx = Assert.Throws<ArgumentNullException>((Action)(() => new EssWebhookService(fakeAzureTableStorageClient, null, fakeAzureBlobStorageClient, fakeEnterpriseEventCacheDataRequestValidator, fakeCacheConfiguration, fakeLogger, fakeEssFulfilmentStorageConfig, fakeFileShareServiceCache, fakeFileShareServiceClient, fakeFileSystemHelper, fakeFileShareServiceConfig, fakeAuthFssTokenProvider)));
             Assert.That(nullAzureServiceEx!.Message, Is.EqualTo("Value cannot be null. (Parameter 'azureStorageService')"));
-            var nullAzureBlobEx = Assert.Throws<ArgumentNullException>(() => new EssWebhookService(fakeAzureTableStorageClient, fakeAzureStorageService, null, fakeEnterpriseEventCacheDataRequestValidator, fakeCacheConfiguration, fakeLogger, fakeEssFulfilmentStorageConfig, fakeFileShareServiceCache, fakeFileShareServiceClient, fakeFileSystemHelper, fakeFileShareServiceConfig, fakeAuthFssTokenProvider));
+            var nullAzureBlobEx = Assert.Throws<ArgumentNullException>((Action)(() => new EssWebhookService(fakeAzureTableStorageClient, fakeAzureStorageService, null, fakeEnterpriseEventCacheDataRequestValidator, fakeCacheConfiguration, fakeLogger, fakeEssFulfilmentStorageConfig, fakeFileShareServiceCache, fakeFileShareServiceClient, fakeFileSystemHelper, fakeFileShareServiceConfig, fakeAuthFssTokenProvider)));
             Assert.That(nullAzureBlobEx!.Message, Is.EqualTo("Value cannot be null. (Parameter 'azureBlobStorageClient')"));
-            var nullCacheEventDataRequestEx = Assert.Throws<ArgumentNullException>(() => new EssWebhookService(fakeAzureTableStorageClient, fakeAzureStorageService, fakeAzureBlobStorageClient, null, fakeCacheConfiguration, fakeLogger, fakeEssFulfilmentStorageConfig, fakeFileShareServiceCache, fakeFileShareServiceClient, fakeFileSystemHelper, fakeFileShareServiceConfig, fakeAuthFssTokenProvider));
+            var nullCacheEventDataRequestEx = Assert.Throws<ArgumentNullException>((Action)(() => new EssWebhookService(fakeAzureTableStorageClient, fakeAzureStorageService, fakeAzureBlobStorageClient, null, fakeCacheConfiguration, fakeLogger, fakeEssFulfilmentStorageConfig, fakeFileShareServiceCache, fakeFileShareServiceClient, fakeFileSystemHelper, fakeFileShareServiceConfig, fakeAuthFssTokenProvider)));
             Assert.That(nullCacheEventDataRequestEx!.Message, Is.EqualTo("Value cannot be null. (Parameter 'enterpriseEventCacheDataRequestValidator')"));
-            var nullCacheConfigEx = Assert.Throws<ArgumentNullException>(() => new EssWebhookService(fakeAzureTableStorageClient, fakeAzureStorageService, fakeAzureBlobStorageClient, fakeEnterpriseEventCacheDataRequestValidator, null, fakeLogger, fakeEssFulfilmentStorageConfig, fakeFileShareServiceCache, fakeFileShareServiceClient, fakeFileSystemHelper, fakeFileShareServiceConfig, fakeAuthFssTokenProvider));
+            var nullCacheConfigEx = Assert.Throws<ArgumentNullException>((Action)(() => new EssWebhookService(fakeAzureTableStorageClient, fakeAzureStorageService, fakeAzureBlobStorageClient, fakeEnterpriseEventCacheDataRequestValidator, null, fakeLogger, fakeEssFulfilmentStorageConfig, fakeFileShareServiceCache, fakeFileShareServiceClient, fakeFileSystemHelper, fakeFileShareServiceConfig, fakeAuthFssTokenProvider)));
             Assert.That(nullCacheConfigEx!.Message, Is.EqualTo("Value cannot be null. (Parameter 'cacheConfiguration')"));
-            var nullLoggerEx = Assert.Throws<ArgumentNullException>(() => new EssWebhookService(fakeAzureTableStorageClient, fakeAzureStorageService, fakeAzureBlobStorageClient, fakeEnterpriseEventCacheDataRequestValidator, fakeCacheConfiguration, null, fakeEssFulfilmentStorageConfig, fakeFileShareServiceCache, fakeFileShareServiceClient, fakeFileSystemHelper, fakeFileShareServiceConfig, fakeAuthFssTokenProvider));
+            var nullLoggerEx = Assert.Throws<ArgumentNullException>((Action)(() => new EssWebhookService(fakeAzureTableStorageClient, fakeAzureStorageService, fakeAzureBlobStorageClient, fakeEnterpriseEventCacheDataRequestValidator, fakeCacheConfiguration, null, fakeEssFulfilmentStorageConfig, fakeFileShareServiceCache, fakeFileShareServiceClient, fakeFileSystemHelper, fakeFileShareServiceConfig, fakeAuthFssTokenProvider)));
             Assert.That(nullLoggerEx!.Message, Is.EqualTo("Value cannot be null. (Parameter 'logger')"));
-            var nullFulFilmentStorageEx = Assert.Throws<ArgumentNullException>(() => new EssWebhookService(fakeAzureTableStorageClient, fakeAzureStorageService, fakeAzureBlobStorageClient, fakeEnterpriseEventCacheDataRequestValidator, fakeCacheConfiguration, fakeLogger, null, fakeFileShareServiceCache, fakeFileShareServiceClient, fakeFileSystemHelper, fakeFileShareServiceConfig, fakeAuthFssTokenProvider));
+            var nullFulFilmentStorageEx = Assert.Throws<ArgumentNullException>((Action)(() => new EssWebhookService(fakeAzureTableStorageClient, fakeAzureStorageService, fakeAzureBlobStorageClient, fakeEnterpriseEventCacheDataRequestValidator, fakeCacheConfiguration, fakeLogger, null, fakeFileShareServiceCache, fakeFileShareServiceClient, fakeFileSystemHelper, fakeFileShareServiceConfig, fakeAuthFssTokenProvider)));
             Assert.That(nullFulFilmentStorageEx!.Message, Is.EqualTo("Value cannot be null. (Parameter 'essFulfilmentStorageconfig')"));
-            var nullFssCacheStorageEx = Assert.Throws<ArgumentNullException>(() => new EssWebhookService(fakeAzureTableStorageClient, fakeAzureStorageService, fakeAzureBlobStorageClient, fakeEnterpriseEventCacheDataRequestValidator, fakeCacheConfiguration, fakeLogger, fakeEssFulfilmentStorageConfig, null, fakeFileShareServiceClient, fakeFileSystemHelper, fakeFileShareServiceConfig, fakeAuthFssTokenProvider));
+            var nullFssCacheStorageEx = Assert.Throws<ArgumentNullException>((Action)(() => new EssWebhookService(fakeAzureTableStorageClient, fakeAzureStorageService, fakeAzureBlobStorageClient, fakeEnterpriseEventCacheDataRequestValidator, fakeCacheConfiguration, fakeLogger, fakeEssFulfilmentStorageConfig, null, fakeFileShareServiceClient, fakeFileSystemHelper, fakeFileShareServiceConfig, fakeAuthFssTokenProvider)));
             Assert.That(nullFssCacheStorageEx!.Message, Is.EqualTo("Value cannot be null. (Parameter 'fileShareServiceCache')"));
-            var nullFssClientEx = Assert.Throws<ArgumentNullException>(() => new EssWebhookService(fakeAzureTableStorageClient, fakeAzureStorageService, fakeAzureBlobStorageClient, fakeEnterpriseEventCacheDataRequestValidator, fakeCacheConfiguration, fakeLogger, fakeEssFulfilmentStorageConfig, fakeFileShareServiceCache, null, fakeFileSystemHelper, fakeFileShareServiceConfig, fakeAuthFssTokenProvider));
+            var nullFssClientEx = Assert.Throws<ArgumentNullException>((Action)(() => new EssWebhookService(fakeAzureTableStorageClient, fakeAzureStorageService, fakeAzureBlobStorageClient, fakeEnterpriseEventCacheDataRequestValidator, fakeCacheConfiguration, fakeLogger, fakeEssFulfilmentStorageConfig, fakeFileShareServiceCache, null, fakeFileSystemHelper, fakeFileShareServiceConfig, fakeAuthFssTokenProvider)));
             Assert.That(nullFssClientEx!.Message, Is.EqualTo("Value cannot be null. (Parameter 'fileShareServiceClient')"));
-            var nullFileSystemHelperEx = Assert.Throws<ArgumentNullException>(() => new EssWebhookService(fakeAzureTableStorageClient, fakeAzureStorageService, fakeAzureBlobStorageClient, fakeEnterpriseEventCacheDataRequestValidator, fakeCacheConfiguration, fakeLogger, fakeEssFulfilmentStorageConfig, fakeFileShareServiceCache, fakeFileShareServiceClient, null, fakeFileShareServiceConfig, fakeAuthFssTokenProvider));
+            var nullFileSystemHelperEx = Assert.Throws<ArgumentNullException>((Action)(() => new EssWebhookService(fakeAzureTableStorageClient, fakeAzureStorageService, fakeAzureBlobStorageClient, fakeEnterpriseEventCacheDataRequestValidator, fakeCacheConfiguration, fakeLogger, fakeEssFulfilmentStorageConfig, fakeFileShareServiceCache, fakeFileShareServiceClient, null, fakeFileShareServiceConfig, fakeAuthFssTokenProvider)));
             Assert.That(nullFileSystemHelperEx!.Message, Is.EqualTo("Value cannot be null. (Parameter 'fileSystemHelper')"));
-            var nullFssConfigEx = Assert.Throws<ArgumentNullException>(() => new EssWebhookService(fakeAzureTableStorageClient, fakeAzureStorageService, fakeAzureBlobStorageClient, fakeEnterpriseEventCacheDataRequestValidator, fakeCacheConfiguration, fakeLogger, fakeEssFulfilmentStorageConfig, fakeFileShareServiceCache, fakeFileShareServiceClient, fakeFileSystemHelper, null, fakeAuthFssTokenProvider));
+            var nullFssConfigEx = Assert.Throws<ArgumentNullException>((Action)(() => new EssWebhookService(fakeAzureTableStorageClient, fakeAzureStorageService, fakeAzureBlobStorageClient, fakeEnterpriseEventCacheDataRequestValidator, fakeCacheConfiguration, fakeLogger, fakeEssFulfilmentStorageConfig, fakeFileShareServiceCache, fakeFileShareServiceClient, fakeFileSystemHelper, null, fakeAuthFssTokenProvider)));
             Assert.That(nullFssConfigEx!.Message, Is.EqualTo("Value cannot be null. (Parameter 'fileShareServiceConfig')"));
-            var nullAuthTokenProviderEx = Assert.Throws<ArgumentNullException>(() => new EssWebhookService(fakeAzureTableStorageClient, fakeAzureStorageService, fakeAzureBlobStorageClient, fakeEnterpriseEventCacheDataRequestValidator, fakeCacheConfiguration, fakeLogger, fakeEssFulfilmentStorageConfig, fakeFileShareServiceCache, fakeFileShareServiceClient, fakeFileSystemHelper, fakeFileShareServiceConfig, null));
+            var nullAuthTokenProviderEx = Assert.Throws<ArgumentNullException>((Action)(() => new EssWebhookService(fakeAzureTableStorageClient, fakeAzureStorageService, fakeAzureBlobStorageClient, fakeEnterpriseEventCacheDataRequestValidator, fakeCacheConfiguration, fakeLogger, fakeEssFulfilmentStorageConfig, fakeFileShareServiceCache, fakeFileShareServiceClient, fakeFileSystemHelper, fakeFileShareServiceConfig, null)));
             Assert.That(nullAuthTokenProviderEx!.Message, Is.EqualTo("Value cannot be null. (Parameter 'authFssTokenProvider')"));
 
         }

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Services/ProductDataServiceTests.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/Services/ProductDataServiceTests.cs
@@ -315,11 +315,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
 
             var result = await service.ValidateProductDataByProductIdentifiers(new ProductIdentifierRequest());
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.IsValid, Is.False);
                 Assert.That(result.Errors.Single().ErrorMessage, Is.EqualTo("Product Identifiers cannot be blank or null."));
-            });
+            }
         }
 
         [Test]
@@ -330,11 +330,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                     {new ValidationFailure("RequestBody", "Either body is null or malformed.")}));
 
             var result = await service.ValidateProductDataByProductIdentifiers(null);
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.IsValid, Is.False);
                 Assert.That(result.Errors.Single().ErrorMessage, Is.EqualTo("Either body is null or malformed."));
-            });
+            }
         }
 
         [Test]
@@ -381,11 +381,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                     CallbackUri = callbackUri
                 }, azureB2CToken); //B2C Token with file Size less than 300 mb
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result, Is.InstanceOf<ExchangeSetServiceResponse>());
                 Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
-            });
+            }
         }
 
         [Test]
@@ -410,11 +410,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                     CallbackUri = callbackUri
                 }, azureAdB2CToken); //AdB2C token with file size large than 300 mb
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result, Is.InstanceOf<ExchangeSetServiceResponse>());
                 Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
-            });
+            }
         }
 
         [Test]
@@ -489,11 +489,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                     CallbackUri = callbackUri
                 }, azureB2CToken); // AzureB2C Token but file size is less than 300 Mb
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.Created));
                 Assert.That(result.LastModified, Is.Not.Null);
-            });
+            }
 
             A.CallTo(logger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -527,11 +527,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                     CallbackUri = callbackUri
                 }, azureAdB2CToken);//azure Ad B2C token when file size is less than 300 Mb
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result, Is.InstanceOf<ExchangeSetServiceResponse>());
                 Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.InternalServerError));
-            });
+            }
         }
 
         [Test]
@@ -567,11 +567,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                     ExchangeSetStandard = exchangeSetStandard.ToString()
                 }, azureAdToken);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.ExchangeSetResponse, Is.Null);
                 Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.InternalServerError));
-            });
+            }
         }
 
         [Test]
@@ -775,11 +775,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
             var result = await service.ValidateProductDataByProductVersions(new ProductDataProductVersionsRequest()
             { ProductVersions = new List<ProductVersionRequest>() { new ProductVersionRequest() { ProductName = null } } });
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.IsValid, Is.False);
                 Assert.That(result.Errors.Single().ErrorMessage, Is.EqualTo("productName cannot be blank or null."));
-            });
+            }
         }
 
         [Test]
@@ -791,11 +791,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
 
             var result = await service.ValidateProductDataByProductVersions(null);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.IsValid, Is.False);
                 Assert.That(result.Errors.Single().ErrorMessage, Is.EqualTo("Either body is null or malformed."));
-            });
+            }
         }
 
         [Test]
@@ -828,11 +828,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                 CallbackUri = ""
             }, azureB2CToken);//valid AzureAdB2c Token , but filesize is large than 300 mb
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result, Is.InstanceOf<ExchangeSetServiceResponse>());
                 Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
-            });
+            }
         }
 
         [Test]
@@ -853,11 +853,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                 CallbackUri = ""
             }, azureAdB2CToken);//valid AzureAdB2c Token , but filesize is large than 300 mb
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result, Is.InstanceOf<ExchangeSetServiceResponse>());
                 Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
-            });
+            }
         }
 
         [Test]
@@ -951,7 +951,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
             exchangeSetResponsWithOutAio.RequestedProductsAlreadyUpToDateCount = 3;//RequestedProductsAlreadyUpToDateCount
 
             Assert.That(result, Is.InstanceOf<ExchangeSetServiceResponse>());
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.Created));
                 Assert.That(result.LastModified, Is.Null);
@@ -960,7 +960,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                 Assert.That(exchangeSetResponsWithOutAio.RequestedProductsAlreadyUpToDateCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductsAlreadyUpToDateCount));
                 Assert.That(exchangeSetResponsWithOutAio.ExchangeSetUrlExpiryDateTime, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetUrlExpiryDateTime));
                 Assert.That(exchangeSetResponsWithOutAio.BatchId, Is.EqualTo(result.BatchId));
-            });
+            }
 
             A.CallTo(logger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -1014,7 +1014,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
             exchangeSetResponseWithOutAio.RequestedProductsAlreadyUpToDateCount = 3;//RequestedProductsAlreadyUpToDateCount
 
             Assert.That(result, Is.InstanceOf<ExchangeSetServiceResponse>());
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.Created));
                 Assert.That(result.LastModified, Is.Not.Null);
@@ -1023,7 +1023,7 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                 Assert.That(exchangeSetResponseWithOutAio.RequestedProductsAlreadyUpToDateCount, Is.EqualTo(result.ExchangeSetResponse.RequestedProductsAlreadyUpToDateCount));
                 Assert.That(exchangeSetResponseWithOutAio.ExchangeSetUrlExpiryDateTime, Is.EqualTo(result.ExchangeSetResponse.ExchangeSetUrlExpiryDateTime));
                 Assert.That(exchangeSetResponseWithOutAio.BatchId, Is.EqualTo(result.BatchId));
-            });
+            }
 
             A.CallTo(logger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
@@ -1061,11 +1061,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
             }, azureADToken);
 
             Assert.That(result, Is.InstanceOf<ExchangeSetServiceResponse>());
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.InternalServerError));
                 Assert.That(result.LastModified, Is.Null);
-            });
+            }
         }
 
         [Test]
@@ -1097,11 +1097,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                 ExchangeSetStandard = exchangeSetStandard.ToString()
             }, azureAdToken);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.ExchangeSetResponse, Is.Null);
                 Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.InternalServerError));
-            });
+            }
         }
 
         [Test]
@@ -1322,11 +1322,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
 
             var result = await service.ValidateScsProductDataByProductIdentifiers(new ScsProductIdentifierRequest());
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.IsValid, Is.False);
                 Assert.That(result.Errors.Single().ErrorMessage, Is.EqualTo("Product Identifiers cannot be blank or null."));
-            });
+            }
         }
 
         [Test]
@@ -1337,11 +1337,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
                     {new ValidationFailure("RequestBody", "Either body is null or malformed.")}));
 
             var result = await service.ValidateScsProductDataByProductIdentifiers(null);
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.IsValid, Is.False);
                 Assert.That(result.Errors.Single().ErrorMessage, Is.EqualTo("Either body is null or malformed."));
-            });
+            }
         }
 
         [Test]
@@ -1415,11 +1415,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
 
             var result = await service.ValidateProductDataSinceDateTime(new ProductDataSinceDateTimeRequest());
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.IsValid, Is.False);
                 Assert.That(result.Errors.Single().ErrorMessage, Is.EqualTo("Provided sinceDateTime is either invalid or invalid format, the valid format is 'RFC1123 format'."));
-            });
+            }
         }
 
         [Test]
@@ -1431,11 +1431,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
 
             var result = await service.ValidateProductDataSinceDateTime(new ProductDataSinceDateTimeRequest());
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.IsValid, Is.False);
                 Assert.That(result.Errors.Single().ErrorMessage, Is.EqualTo("Provided sinceDateTime cannot be a future date."));
-            });
+            }
         }
 
         [Test]
@@ -1447,11 +1447,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
 
             var result = await service.ValidateProductDataSinceDateTime(new ProductDataSinceDateTimeRequest());
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.IsValid, Is.False);
                 Assert.That(result.Errors.Single().ErrorMessage, Is.EqualTo("Invalid callbackUri format."));
-            });
+            }
         }
 
         [Test]
@@ -1625,11 +1625,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
 
             var result = await service.CreateProductDataSinceDateTime(new ProductDataSinceDateTimeRequest(), GetAzureAdB2CToken());// ADB2C Token with File size less than 300 mb
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.ExchangeSetResponse, Is.Null);
                 Assert.That(result.HttpStatusCode, Is.EqualTo(HttpStatusCode.InternalServerError));
-            });
+            }
         }
 
         [Test]
@@ -1835,11 +1835,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
 
             var result = await service.ValidateScsDataSinceDateTime(new ProductDataSinceDateTimeRequest());
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.IsValid, Is.False);
                 Assert.That(result.Errors.Single().ErrorMessage, Is.EqualTo("Provided sinceDateTime is either invalid or invalid format, the valid format is 'RFC1123 format'."));
-            });
+            }
         }
 
         [Test]
@@ -1851,11 +1851,11 @@ namespace UKHO.ExchangeSetService.API.UnitTests.Services
 
             var result = await service.ValidateScsDataSinceDateTime(new ProductDataSinceDateTimeRequest());
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.IsValid, Is.False);
                 Assert.That(result.Errors.Single().ErrorMessage, Is.EqualTo("Provided sinceDateTime cannot be a future date."));
-            });
+            }
         }
 
         #endregion ScsProductDataSinceDateTime

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/UKHO.ExchangeSetService.API.UnitTests.csproj
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.API.UnitTests/UKHO.ExchangeSetService.API.UnitTests.csproj
@@ -11,19 +11,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
+    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FakeItEasy" Version="8.3.0" />
+    <PackageReference Include="FakeItEasy" Version="9.0.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.10" />
-    <PackageReference Include="NUnit" Version="4.5.1" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.12.0">
+    <PackageReference Include="NUnit" Version="4.6.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
   </ItemGroup>
 

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common.UnitTests/HealthCheck/AzureWebJobsHealthCheckServiceTest.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common.UnitTests/HealthCheck/AzureWebJobsHealthCheckServiceTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Configuration;
 using System.Threading.Tasks;
 using FakeItEasy;
@@ -94,7 +95,7 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.HealthCheck
         {
             _essFulfilmentStorageConfiguration = new EssFulfilmentStorageConfiguration { ExchangeSetTypes = "osx,sxs,mxs,lxs", WebAppVersion = "" };
 
-            Assert.ThrowsAsync<ConfigurationErrorsException>(() => _azureWebJobsHealthCheckService.CheckHealthAsync());
+            Assert.ThrowsAsync<ConfigurationErrorsException>((Func<Task>)(async () => await _azureWebJobsHealthCheckService.CheckHealthAsync()));
         }
     }
 }

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common.UnitTests/Helpers/AzureBlobStorageServiceTest.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common.UnitTests/Helpers/AzureBlobStorageServiceTest.cs
@@ -153,7 +153,7 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
 
             Assert.ThrowsAsync(Is.TypeOf<KeyNotFoundException>()
                    .And.Message.EqualTo("Storage account credentials missing from config")
-                    , async delegate { await azureBlobStorageService.DownloadSalesCatalogueResponse(scsResponseUri, fakeBatchId, null); });
+                    , (Func<Task>)(async () => await azureBlobStorageService.DownloadSalesCatalogueResponse(scsResponseUri, fakeBatchId, null)));
         }
 
         [Test]
@@ -173,7 +173,7 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
             var response = await azureBlobStorageService.DownloadSalesCatalogueResponse(scsResponseUri, fakeBatchId, null);
 
             Assert.That(response, Is.InstanceOf<SalesCatalogueProductResponse>());
-            Assert.That(response.Products[0].ProductName,Is.EqualTo("DE5NOBRK"));
+            Assert.That(response.Products[0].ProductName, Is.EqualTo("DE5NOBRK"));
             Assert.That(response.Products[0].EditionNumber, Is.EqualTo(1));
             Assert.That(response.Products[0].UpdateNumbers[0].Value, Is.EqualTo(0));
         }

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common.UnitTests/Helpers/FileShareServiceCacheTest.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common.UnitTests/Helpers/FileShareServiceCacheTest.cs
@@ -1,17 +1,19 @@
-﻿using FakeItEasy;
-using Azure.Data.Tables;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using Azure.Storage.Blobs;
-using Newtonsoft.Json;
-using NUnit.Framework;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure;
+using Azure.Data.Tables;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using FakeItEasy;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using NUnit.Framework;
 using UKHO.ExchangeSetService.Common.Configuration;
 using UKHO.ExchangeSetService.Common.Helpers;
 using UKHO.ExchangeSetService.Common.Logging;
@@ -20,8 +22,6 @@ using UKHO.ExchangeSetService.Common.Models.FileShareService.Response;
 using UKHO.ExchangeSetService.Common.Models.SalesCatalogue;
 using UKHO.ExchangeSetService.Common.Storage;
 using Attribute = UKHO.ExchangeSetService.Common.Models.FileShareService.Response.Attribute;
-using Azure;
-using Azure.Storage.Blobs.Models;
 
 namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
 {
@@ -260,7 +260,7 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
             cancellationTokenSource.Cancel();
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            Assert.ThrowsAsync<OperationCanceledException>(async () => await fileShareServiceCache.GetNonCachedProductDataForFss(GetProductdetails(), GetSearchBatchResponse(), string.Empty, GetScsResponseQueueMessage(), cancellationTokenSource, cancellationToken, businessUnit));
+            Assert.ThrowsAsync<OperationCanceledException>((Func<Task>)(async () => await fileShareServiceCache.GetNonCachedProductDataForFss(GetProductdetails(), GetSearchBatchResponse(), string.Empty, GetScsResponseQueueMessage(), cancellationTokenSource, cancellationToken, businessUnit)));
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Error
@@ -344,7 +344,7 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
             CommonHelper.IsLargeLayout = false;
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(fulfilmentExceptionMessage),
-                 async delegate { await fileShareServiceCache.GetNonCachedProductDataForFss(GetProductdetails(), GetSearchBatchResponse(), exchangeSetRootPath, GetScsResponseQueueMessage(), null, CancellationToken.None, businessUnit); });
+                 (Func<Task>)(async () => await fileShareServiceCache.GetNonCachedProductDataForFss(GetProductdetails(), GetSearchBatchResponse(), exchangeSetRootPath, GetScsResponseQueueMessage(), null, CancellationToken.None, businessUnit)));
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common.UnitTests/Helpers/FileShareServiceTests.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common.UnitTests/Helpers/FileShareServiceTests.cs
@@ -389,7 +389,7 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
                  .Returns(new HttpResponseMessage() { StatusCode = HttpStatusCode.BadRequest, RequestMessage = new HttpRequestMessage() { RequestUri = new Uri("http://test.com") }, Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes("Bad request"))) });
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(fulfilmentExceptionMessage),
-                  async delegate { await fileShareService.GetBatchInfoBasedOnProducts(GetProductdetails(), GetScsResponseQueueMessage(), cancellationTokenSource, CancellationToken.None, string.Empty, businessUnit); });
+                  (Func<Task>)(async () => await fileShareService.GetBatchInfoBasedOnProducts(GetProductdetails(), GetScsResponseQueueMessage(), cancellationTokenSource, CancellationToken.None, string.Empty, businessUnit)));
         }
 
         [Test]
@@ -497,7 +497,7 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
             });
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(fulfilmentExceptionMessage),
-                async delegate { await fileShareService.GetBatchInfoBasedOnProducts(productList, GetScsResponseQueueMessage(), cancellationTokenSource, CancellationToken.None, string.Empty, businessUnit); });
+                (Func<Task>)(async () => await fileShareService.GetBatchInfoBasedOnProducts(productList, GetScsResponseQueueMessage(), cancellationTokenSource, CancellationToken.None, string.Empty, businessUnit)));
         }
 
         [Test]
@@ -656,7 +656,7 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
             });
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(fulfilmentExceptionMessage),
-                async delegate { await fileShareService.GetBatchInfoBasedOnProducts(productList, GetScsResponseQueueMessage(), cancellationTokenSource, CancellationToken.None, string.Empty, businessUnit); });
+                (Func<Task>)(async () => await fileShareService.GetBatchInfoBasedOnProducts(productList, GetScsResponseQueueMessage(), cancellationTokenSource, CancellationToken.None, string.Empty, businessUnit)));
 
         }
         #endregion GetBatchInfoBasedOnProducts
@@ -744,7 +744,7 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
                  });
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(fulfilmentExceptionMessage),
-                 async delegate { await fileShareService.DownloadBatchFiles(batchDetail.Entries[0], new List<string> { fakeFilePath }, fakeFolderPath, GetScsResponseQueueMessage(), cancellationTokenSource, CancellationToken.None); });
+                 (Func<Task>)(async () => await fileShareService.DownloadBatchFiles(batchDetail.Entries[0], new List<string> { fakeFilePath }, fakeFolderPath, GetScsResponseQueueMessage(), cancellationTokenSource, CancellationToken.None)));
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Error
@@ -775,7 +775,7 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
 
             cancellationTokenSource.Cancel();
             CancellationToken cancellationToken = cancellationTokenSource.Token;
-            Assert.ThrowsAsync<OperationCanceledException>(async () => await fileShareService.DownloadBatchFiles(batchDetail.Entries[0], new List<string> { fakeFilePath }, fakeFolderPath, GetScsResponseQueueMessage(), cancellationTokenSource, cancellationToken));
+            Assert.ThrowsAsync<OperationCanceledException>((Func<Task>)(async () => await fileShareService.DownloadBatchFiles(batchDetail.Entries[0], new List<string> { fakeFilePath }, fakeFolderPath, GetScsResponseQueueMessage(), cancellationTokenSource, cancellationToken)));
         }
 
         [Test]
@@ -807,7 +807,7 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
 
             cancellationTokenSource.Cancel();
             CancellationToken cancellationToken = cancellationTokenSource.Token;
-            Assert.ThrowsAsync<OperationCanceledException>(async () => await fileShareService.GetBatchInfoBasedOnProducts(productList, GetScsResponseQueueMessage(), cancellationTokenSource, cancellationToken, string.Empty, businessUnit));
+            Assert.ThrowsAsync<OperationCanceledException>((Func<Task>)(async () => await fileShareService.GetBatchInfoBasedOnProducts(productList, GetScsResponseQueueMessage(), cancellationTokenSource, cancellationToken, string.Empty, businessUnit)));
         }
 
         #endregion
@@ -821,7 +821,7 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
                  .Returns(new HttpResponseMessage() { StatusCode = HttpStatusCode.BadRequest, RequestMessage = new HttpRequestMessage() { RequestUri = new Uri("http://test.com") }, Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes("Bad request"))) });
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(fulfilmentExceptionMessage),
-                  async delegate { await fileShareService.SearchReadMeFilePath(string.Empty, string.Empty); });
+                  (Func<Task>)(async () => await fileShareService.SearchReadMeFilePath(string.Empty, string.Empty)));
         }
 
         [Test]
@@ -850,7 +850,7 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
                .Returns(httpResponse);
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(fulfilmentExceptionMessage),
-                  async delegate { await fileShareService.SearchReadMeFilePath(batchId, string.Empty); });
+                  (Func<Task>)(async () => await fileShareService.SearchReadMeFilePath(batchId, string.Empty)));
         }
 
         [Test]
@@ -960,7 +960,7 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
                .Returns(httpResponse);
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(fulfilmentExceptionMessage),
-                 async delegate { await fileShareService.DownloadReadMeFileFromFssAsync(readMeFilePath, batchId, exchangeSetRootPath, null); });
+                 (Func<Task>)(async () => await fileShareService.DownloadReadMeFileFromFssAsync(readMeFilePath, batchId, exchangeSetRootPath, null)));
         }
         #endregion
 
@@ -972,7 +972,7 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
             A.CallTo(() => fakeFileSystemHelper.CheckDirectoryAndFileExists(A<string>.Ignored, A<string>.Ignored)).Returns(false);
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(fulfilmentExceptionMessage),
-                  async delegate { await fileShareService.CreateZipFileForExchangeSet(fakeBatchId, string.Empty, string.Empty); });
+                  (Func<Task>)(async () => await fileShareService.CreateZipFileForExchangeSet(fakeBatchId, string.Empty, string.Empty)));
         }
 
         [Test]
@@ -1013,7 +1013,7 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
              });
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(fulfilmentExceptionMessage),
-                   async delegate { await fileShareService.UploadFileToFileShareService(fakeBatchId, fakeExchangeSetPath, null, fakeFileShareConfig.Value.ExchangeSetFileName); });
+                   (Func<Task>)(async () => await fileShareService.UploadFileToFileShareService(fakeBatchId, fakeExchangeSetPath, null, fakeFileShareConfig.Value.ExchangeSetFileName)));
         }
 
         [Test]
@@ -1047,7 +1047,7 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
              });
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(fulfilmentExceptionMessage),
-                  async delegate { await fileShareService.UploadFileToFileShareService(fakeBatchId, fakeExchangeSetPath, null, fakeFileShareConfig.Value.ExchangeSetFileName); });
+                  (Func<Task>)(async () => await fileShareService.UploadFileToFileShareService(fakeBatchId, fakeExchangeSetPath, null, fakeFileShareConfig.Value.ExchangeSetFileName)));
         }
 
         [Test]
@@ -1077,7 +1077,7 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
             });
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(fulfilmentExceptionMessage),
-                async delegate { await fileShareService.CommitBatchToFss(fakeBatchId, fakeCorrelationId, fakeExchangeSetPath); });
+                (Func<Task>)(async () => await fileShareService.CommitBatchToFss(fakeBatchId, fakeCorrelationId, fakeExchangeSetPath)));
         }
 
         [Test]
@@ -1110,7 +1110,7 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
             });
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(fulfilmentExceptionMessage),
-                   async delegate { await fileShareService.CommitBatchToFss(fakeBatchId, fakeCorrelationId, fakeExchangeSetPath); });
+                   (Func<Task>)(async () => await fileShareService.CommitBatchToFss(fakeBatchId, fakeCorrelationId, fakeExchangeSetPath)));
         }
 
         [Test]
@@ -1192,7 +1192,7 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
                 .Returns(badUploadResponse);
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(fulfilmentExceptionMessage),
-                   async delegate { await fileShareService.UploadFileToFileShareService(fakeBatchId, fakeExchangeSetPath, null, fakeFileShareConfig.Value.ExchangeSetFileName); });
+                   (Func<Task>)(async () => await fileShareService.UploadFileToFileShareService(fakeBatchId, fakeExchangeSetPath, null, fakeFileShareConfig.Value.ExchangeSetFileName)));
         }
         #endregion UploadZipFile
 
@@ -1372,7 +1372,7 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
                 .Returns(badUploadResponse);
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(fulfilmentExceptionMessage),
-                   async delegate { await fileShareService.UploadFileToFileShareService(fakeBatchId, fakeExchangeSetPath, null, fakeLargeMediaZipFilePath); });
+                   (Func<Task>)(async () => await fileShareService.UploadFileToFileShareService(fakeBatchId, fakeExchangeSetPath, null, fakeLargeMediaZipFilePath)));
         }
 
         [Test]
@@ -1423,7 +1423,7 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
                 .Returns(badCommitBatchResponse);
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(fulfilmentExceptionMessage),
-                   async delegate { await fileShareService.CommitAndGetBatchStatusForLargeMediaExchangeSet(fakeBatchId, fakeExchangeSetPath, null); });
+                   (Func<Task>)(async () => await fileShareService.CommitAndGetBatchStatusForLargeMediaExchangeSet(fakeBatchId, fakeExchangeSetPath, null)));
         }
 
         [Test]
@@ -1447,7 +1447,7 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
                 .Returns(httpResponse);
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(fulfilmentExceptionMessage),
-                   async delegate { await fileShareService.CommitAndGetBatchStatusForLargeMediaExchangeSet(fakeBatchId, fakeExchangeSetPath, null); });
+                   (Func<Task>)(async () => await fileShareService.CommitAndGetBatchStatusForLargeMediaExchangeSet(fakeBatchId, fakeExchangeSetPath, null)));
         }
 
         #region SearchFolderFiles
@@ -1515,7 +1515,7 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
                .Returns(httpResponse);
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(fulfilmentExceptionMessage),
-                 async delegate { await fileShareService.SearchFolderDetails(batchId, string.Empty, searchFolderFileName); });
+                 (Func<Task>)(async () => await fileShareService.SearchFolderDetails(batchId, string.Empty, searchFolderFileName)));
             return Task.CompletedTask;
         }
 
@@ -1527,7 +1527,7 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
                  .Returns(new HttpResponseMessage() { StatusCode = HttpStatusCode.BadRequest, RequestMessage = new HttpRequestMessage() { RequestUri = new Uri("http://test.com") }, Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes("Bad request"))) });
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(fulfilmentExceptionMessage),
-                  async delegate { await fileShareService.SearchFolderDetails(string.Empty, string.Empty, string.Empty); });
+                  (Func<Task>)(async () => await fileShareService.SearchFolderDetails(string.Empty, string.Empty, string.Empty)));
         }
         #endregion SearchFolderFiles 
 
@@ -1599,7 +1599,7 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
             };
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(fulfilmentExceptionMessage),
-                 async delegate { await fileShareService.DownloadFolderDetails(fakeBatchId, correlationidParam, batchFileList, fakeExchangeSetPath); });
+                 (Func<Task>)(async () => await fileShareService.DownloadFolderDetails(fakeBatchId, correlationidParam, batchFileList, fakeExchangeSetPath)));
         }
         #endregion DownloadFolderFiles 
 

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common.UnitTests/Helpers/SalesCatalogueServiceTests.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common.UnitTests/Helpers/SalesCatalogueServiceTests.cs
@@ -1,20 +1,20 @@
-﻿using FakeItEasy;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using NUnit.Framework;
-using System;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
-using UKHO.ExchangeSetService.Common.Configuration;
-using System.Collections.Generic;
-using UKHO.ExchangeSetService.Common.Models.SalesCatalogue;
+using FakeItEasy;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
-using UKHO.ExchangeSetService.Common.Models.Request;
-using UKHO.ExchangeSetService.Common.Helpers.SalesCatalogue;
+using NUnit.Framework;
+using UKHO.ExchangeSetService.Common.Configuration;
 using UKHO.ExchangeSetService.Common.Helpers.Auth;
+using UKHO.ExchangeSetService.Common.Helpers.SalesCatalogue;
+using UKHO.ExchangeSetService.Common.Models.Request;
+using UKHO.ExchangeSetService.Common.Models.SalesCatalogue;
 
 namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
 {
@@ -347,7 +347,7 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Helpers
                 .Returns(new HttpResponseMessage() { StatusCode = HttpStatusCode.BadRequest, RequestMessage = new HttpRequestMessage() { RequestUri = new Uri("http://abc.com") }, Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes("Bad request"))) });
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(fulfilmentExceptionMessage),
-                 async delegate { await salesCatalogueService.GetSalesCatalogueDataResponse(fakeBatchId, null); });
+                 (Func<Task>)(async () => await salesCatalogueService.GetSalesCatalogueDataResponse(fakeBatchId, null)));
         }
 
         [Test]

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common.UnitTests/Storage/SalesCatalogueStorageServiceTest.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common.UnitTests/Storage/SalesCatalogueStorageServiceTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Microsoft.Extensions.Options;
 using NUnit.Framework;
 using UKHO.ExchangeSetService.Common.Configuration;
@@ -55,7 +56,7 @@ namespace UKHO.ExchangeSetService.Common.UnitTests.Storage
         {
             var expectedErrorMessage = "Storage account accesskey not found";
 
-            var ex = Assert.Throws<KeyNotFoundException>(() => _salesCatalogueStorageService.GetStorageAccountConnectionString(null, null));
+            var ex = Assert.Throws<KeyNotFoundException>((Action)(() => _salesCatalogueStorageService.GetStorageAccountConnectionString(null, null)));
 
             Assert.That(expectedErrorMessage, Is.EqualTo(ex.Message));
         }

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common.UnitTests/UKHO.ExchangeSetService.Common.UnitTests.csproj
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Common.UnitTests/UKHO.ExchangeSetService.Common.UnitTests.csproj
@@ -9,19 +9,18 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
+    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FakeItEasy" Version="8.3.0" />
-    <PackageReference Include="NUnit" Version="4.5.1" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.12.0">
+    <PackageReference Include="FakeItEasy" Version="9.0.1" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="runtime.native.System.Net.Security" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\UKHO.ExchangeSetService.Common\UKHO.ExchangeSetService.Common.csproj" />

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/FileBuilders/ExchangeSetBuilderTest.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/FileBuilders/ExchangeSetBuilderTest.cs
@@ -323,7 +323,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.FileBuilders
 
             A.CallTo(() => _fakeProductDataValidator.Validate(A<List<Products>>.Ignored)).Returns(Task.FromResult(validationResult));
 
-            Assert.ThrowsAsync<FulfilmentException>(async () => await _exchangeSetBuilder.CreateStandardLargeMediaExchangeSet(batch, largeResponse, FakeBatchValue.LargeExchangeSetFolderNamePattern, FakeBatchValue.BatchPath, _cancellationTokenSource, _cancellationToken));
+            Assert.ThrowsAsync<FulfilmentException>((Func<Task>)(async () => await _exchangeSetBuilder.CreateStandardLargeMediaExchangeSet(batch, largeResponse, FakeBatchValue.LargeExchangeSetFolderNamePattern, FakeBatchValue.BatchPath, _cancellationTokenSource, _cancellationToken)));
 
             _fakeLogger.VerifyLogEntry(EventIds.LargeExchangeSetCreatedWithError, "Large media exchange set is not created for BatchId:{BatchId} and _X-Correlation-ID:{CorrelationId}", logLevel: LogLevel.Error);
             _fakeLogger.VerifyLogEntry(EventIds.LargeExchangeSetCreatedWithError, "Operation Cancelled as product validation failed for BatchId:{BatchId}, _X-Correlation-ID:{CorrelationId} and Validation message :{Message}", logLevel: LogLevel.Error);

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/Job/MaintenanceBackgroundJobTest.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/Job/MaintenanceBackgroundJobTest.cs
@@ -51,7 +51,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Job
             var schedule = CrontabSchedule.Parse("0 0 1 * * *", new CrontabSchedule.ParseOptions { IncludingSeconds = true });
             A.CallTo(() => _fakeMaintenanceBackgroundService.GetSchedule()).Returns((false, string.Empty, schedule));
 
-            Assert.DoesNotThrowAsync(async () => await _job.StartAsync(_cancellationTokenSource.Token));
+            Assert.DoesNotThrowAsync((Func<Task>)(async () => await _job.StartAsync(_cancellationTokenSource.Token)));
         }
 
         [Test]

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/Services/FulfilmentAncillaryFilesTest.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/Services/FulfilmentAncillaryFilesTest.cs
@@ -181,7 +181,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
             A.CallTo(() => fakeFileSystemHelper.CheckFileExists(A<string>.Ignored)).Returns(false);
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(FulfilmentExceptionMessage),
-                async delegate { await fulfilmentAncillaryFiles.CreateSerialEncFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetInfoPath, null); });
+                (Func<Task>)(async () => await fulfilmentAncillaryFiles.CreateSerialEncFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetInfoPath, null)));
         }
 
         [Test]
@@ -207,7 +207,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
             var salesCatalogueDataResponse = GetSalesCatalogueDataBadrequestResponse();
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(FulfilmentExceptionMessage),
-                async delegate { await fulfilmentAncillaryFiles.CreateProductFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetInfoPath, null, salesCatalogueDataResponse, fakeScsRequestDateTime); });
+                (Func<Task>)(async () => await fulfilmentAncillaryFiles.CreateProductFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetInfoPath, null, salesCatalogueDataResponse, fakeScsRequestDateTime)));
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Error
@@ -225,7 +225,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
             A.CallTo(() => fakeFileSystemHelper.CreateFileContent(A<string>.Ignored, A<string>.Ignored)).Returns(false);
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(FulfilmentExceptionMessage),
-                async delegate { await fulfilmentAncillaryFiles.CreateProductFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetInfoPath, null, salesCatalogueDataResponse, fakeScsRequestDateTime); });
+                (Func<Task>)(async () => await fulfilmentAncillaryFiles.CreateProductFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetInfoPath, null, salesCatalogueDataResponse, fakeScsRequestDateTime)));
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Error
@@ -297,7 +297,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
             A.CallTo(() => fakeFileSystemHelper.CheckFileExists(FakeBatchValue.CatalogFilePath)).Returns(false);
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(FulfilmentExceptionMessage),
-                async delegate { await fulfilmentAncillaryFiles.CreateCatalogFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetEncRootPath, FakeBatchValue.CorrelationId, null, null, null); });
+                (Func<Task>)(async () => await fulfilmentAncillaryFiles.CreateCatalogFile(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetEncRootPath, FakeBatchValue.CorrelationId, null, null, null)));
 
             A.CallTo(() => fakeFileSystemHelper.CheckFileExists(FakeBatchValue.ReadMeFilePath)).MustHaveHappenedOnceExactly();
             A.CallTo(() => fakeFileSystemHelper.CheckAndCreateFolder(FakeBatchValue.ExchangeSetEncRootPath)).MustHaveHappenedOnceExactly();
@@ -316,7 +316,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
             A.CallTo(() => fakeFileSystemHelper.CheckFileExists(FakeBatchValue.LargeExchangeSetMediaFilePath5)).Returns(false);
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(FulfilmentExceptionMessage),
-                async delegate { await fulfilmentAncillaryFiles.CreateMediaFile(FakeBatchValue.BatchId, FakeBatchValue.LargeExchangeSetMediaPath5, FakeBatchValue.CorrelationId, FakeBatchValue.MediaBaseNumber5); });
+                (Func<Task>)(async () => await fulfilmentAncillaryFiles.CreateMediaFile(FakeBatchValue.BatchId, FakeBatchValue.LargeExchangeSetMediaPath5, FakeBatchValue.CorrelationId, FakeBatchValue.MediaBaseNumber5)));
         }
 
         [Test]
@@ -373,7 +373,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
             A.CallTo(() => fakeFileSystemHelper.CheckFileExists(A<string>.Ignored)).Returns(false);
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(FulfilmentExceptionMessage),
-                async delegate { await fulfilmentAncillaryFiles.CreateLargeMediaSerialEncFile(FakeBatchValue.BatchId, baseFolderPath, FakeBatchValue.CorrelationId, "1", "2"); });
+                (Func<Task>)(async () => await fulfilmentAncillaryFiles.CreateLargeMediaSerialEncFile(FakeBatchValue.BatchId, baseFolderPath, FakeBatchValue.CorrelationId, "1", "2")));
         }
 
         [Test]
@@ -470,7 +470,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
             A.CallTo(() => fakeFileSystemHelper.GetParent(b1Path)).Returns(directoryInfo);
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(FulfilmentExceptionMessage),
-                async delegate { await fulfilmentAncillaryFiles.CreateLargeExchangeSetCatalogFile(FakeBatchValue.BatchId, exchangeSetRootPath, FakeBatchValue.CorrelationId, fulfilmentDataResponse, salesCatalogueDataResponse, salesCatalogueProductResponse); });
+                (Func<Task>)(async () => await fulfilmentAncillaryFiles.CreateLargeExchangeSetCatalogFile(FakeBatchValue.BatchId, exchangeSetRootPath, FakeBatchValue.CorrelationId, fulfilmentDataResponse, salesCatalogueDataResponse, salesCatalogueProductResponse)));
 
             A.CallTo(() => fakeFileSystemHelper.CheckFileExists(outputFileName)).MustHaveHappenedOnceExactly();
         }
@@ -485,7 +485,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
             A.CallTo(() => fakeFileSystemHelper.CheckFileExists(readMeFileName)).Returns(true);
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(FulfilmentExceptionMessage),
-                async delegate { await fulfilmentAncillaryFiles.CreateLargeExchangeSetCatalogFile(FakeBatchValue.BatchId, exchangeSetRootPath, FakeBatchValue.CorrelationId, null, null, null); });
+                (Func<Task>)(async () => await fulfilmentAncillaryFiles.CreateLargeExchangeSetCatalogFile(FakeBatchValue.BatchId, exchangeSetRootPath, FakeBatchValue.CorrelationId, null, null, null)));
 
             A.CallTo(() => fakeFileSystemHelper.CheckFileExists(readMeFileName)).MustHaveHappenedOnceExactly();
             A.CallTo(() => fakeFileSystemHelper.ReadAllBytes(A<string>.Ignored)).MustNotHaveHappened();
@@ -507,7 +507,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
             A.CallTo(() => fakeFileSystemHelper.CheckFileExists(FakeBatchValue.UpdateListFilePath5)).Returns(false);
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(FulfilmentExceptionMessage),
-                async delegate { await fulfilmentAncillaryFiles.CreateEncUpdateCsv(GetSalesCatalogueDataResponse(), FakeBatchValue.LargeExchangeSetMediaInfoPath5, FakeBatchValue.BatchId, FakeBatchValue.CorrelationId); });
+                (Func<Task>)(async () => await fulfilmentAncillaryFiles.CreateEncUpdateCsv(GetSalesCatalogueDataResponse(), FakeBatchValue.LargeExchangeSetMediaInfoPath5, FakeBatchValue.BatchId, FakeBatchValue.CorrelationId)));
 
             A.CallTo(() => fakeFileSystemHelper.WriteStream(FakeBatchValue.UpdateListFilePath5)).MustHaveHappenedOnceExactly();
             A.CallTo(() => fakeFileSystemHelper.CheckFileExists(FakeBatchValue.UpdateListFilePath5)).MustHaveHappenedOnceExactly();
@@ -542,7 +542,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
             A.CallTo(() => fakeFileSystemHelper.CheckFileExists(FakeBatchValue.SerialAioFilePath)).Returns(false);
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(FulfilmentExceptionMessage),
-                async delegate { await fulfilmentAncillaryFiles.CreateSerialAioFile(FakeBatchValue.BatchId, FakeBatchValue.AioExchangeSetPath, FakeBatchValue.CorrelationId, salesCatalogueDataResponse); });
+                (Func<Task>)(async () => await fulfilmentAncillaryFiles.CreateSerialAioFile(FakeBatchValue.BatchId, FakeBatchValue.AioExchangeSetPath, FakeBatchValue.CorrelationId, salesCatalogueDataResponse)));
 
             A.CallTo(fakeLogger).Where(call => call.Method.Name == "Log"
                 && call.GetArgument<LogLevel>(0) == LogLevel.Error

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/Services/FulfilmentCallBackServiceTest.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/Services/FulfilmentCallBackServiceTest.cs
@@ -141,13 +141,13 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
 
             var response = await fulfilmentCallBackService.SendCallBackResponse(salesCatalogueProductResponse, scsResponseQueueMessage);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(response, Is.True);
                 Assert.That(uriParam, Is.EqualTo(scsResponseQueueMessage.CallbackUri));
                 Assert.That(httpMethodParam, Is.EqualTo(HttpMethod.Post));
                 Assert.That(postBodyParam, Is.Not.Null);
-            });
+            }
         }
 
 
@@ -185,13 +185,13 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
 
             var response = await fulfilmentCallBackService.SendCallBackErrorResponse(salesCatalogueProductResponse, scsResponseQueueMessage);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(response, Is.True);
                 Assert.That(uriParam, Is.EqualTo(scsResponseQueueMessage.CallbackUri));
                 Assert.That(httpMethodParam, Is.EqualTo(HttpMethod.Post));
                 Assert.That(postBodyParam, Is.Not.Null);
-            });
+            }
         }
 
         #region ValidateCallbackRequestPayload
@@ -448,11 +448,11 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
                 Assert.That(result.Links.AioExchangeSetFileUri, Is.Null, "AioExchangeSetFileUri should be null");
             }
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.AioExchangeSetCellCount, Is.Not.Null);
                 Assert.That(result.RequestedAioProductsAlreadyUpToDateCount, Is.Not.Null);
-            });
+            }
 
             if (isEncReturned || isEmptyEncExchangeSet || result.RequestedProductsNotInExchangeSet.Count != 0)
             {
@@ -463,11 +463,11 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
                 Assert.That(result.Links.ExchangeSetFileUri, Is.Null);
             }
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.ExchangeSetCellCount, Is.GreaterThanOrEqualTo(0));
                 Assert.That(result.RequestedProductsAlreadyUpToDateCount, Is.GreaterThanOrEqualTo(0));
-            });
+            }
         }
 
         #endregion

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/Services/FulfilmentDataServiceTest.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/Services/FulfilmentDataServiceTest.cs
@@ -288,7 +288,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
             A.CallTo(() => _fakeFulfilmentFileShareService.CreateZipFileForExchangeSet(FakeBatchValue.BatchId, FakeBatchValue.ExchangeSetPath, FakeBatchValue.CorrelationId)).Returns(false);
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(FulfilmentExceptionMessage),
-                async delegate { await _fulfilmentDataService.CreateExchangeSet(batch); });
+                (Func<Task>)(async () => await _fulfilmentDataService.CreateExchangeSet(batch)));
 
             A.CallTo(() => _fakeExchangeSetBuilder.CreateStandardExchangeSet(message, salesCatalogueProductResponse, A<List<Products>>.Ignored, FakeBatchValue.ExchangeSetPath, salesCatalogueDataResponse, businessUnit)).MustHaveHappenedOnceExactly();
             A.CallTo(() => _fakeExchangeSetBuilder.CreateAioExchangeSet(A<FulfilmentServiceBatch>.Ignored, A<List<Products>>.Ignored, A<SalesCatalogueDataResponse>.Ignored, A<SalesCatalogueProductResponse>.Ignored)).MustNotHaveHappened();
@@ -315,7 +315,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
             A.CallTo(() => _fakeAzureBlobStorageService.DownloadSalesCatalogueResponse(message.ScsResponseUri, FakeBatchValue.BatchId, FakeBatchValue.CorrelationId)).Returns(salesCatalogueProductResponse);
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(FulfilmentExceptionMessage),
-                async delegate { await _fulfilmentDataService.CreateExchangeSet(batch); });
+                (Func<Task>)(async () => await _fulfilmentDataService.CreateExchangeSet(batch)));
         }
 
         #region AIO
@@ -562,7 +562,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
             A.CallTo(() => _fakeExchangeSetBuilder.CreateAioExchangeSet(batch, A<List<Products>>.Ignored, A<SalesCatalogueDataResponse>.Ignored, salesCatalogueProductResponse)).Returns(false);
 
             Assert.ThrowsAsync(Is.TypeOf<FulfilmentException>().And.Message.EqualTo(FulfilmentExceptionMessage),
-                async delegate { await _fulfilmentDataService.CreateLargeExchangeSet(batch, FakeBatchValue.LargeExchangeSetFolderNamePattern); });
+                (Func<Task>)(async () => await _fulfilmentDataService.CreateLargeExchangeSet(batch, FakeBatchValue.LargeExchangeSetFolderNamePattern)));
 
             A.CallTo(() => _fakeFulfilmentSalesCatalogueService.GetSalesCatalogueDataResponse(FakeBatchValue.BatchId, FakeBatchValue.CorrelationId)).MustHaveHappenedOnceExactly();
             A.CallTo(() => _fakeAzureBlobStorageService.DownloadSalesCatalogueResponse(message.ScsResponseUri, FakeBatchValue.BatchId, FakeBatchValue.CorrelationId)).MustHaveHappenedOnceExactly();

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/Services/FulfilmentFileShareServiceTest.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/Services/FulfilmentFileShareServiceTest.cs
@@ -115,7 +115,7 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
             cancellationTokenSource.Cancel();
             var cancellationToken = cancellationTokenSource.Token;
 
-            Assert.ThrowsAsync<OperationCanceledException>(async () => await fulfilmentFileShareService.QueryFileShareServiceData(GetProductdetails(), GetScsResponseQueueMessage(), cancellationTokenSource, cancellationToken, FakeBatchValue.ExchangeSetEncRootPath, businessUnit));
+            Assert.ThrowsAsync<OperationCanceledException>((Func<Task>)(async () => await fulfilmentFileShareService.QueryFileShareServiceData(GetProductdetails(), GetScsResponseQueueMessage(), cancellationTokenSource, cancellationToken, FakeBatchValue.ExchangeSetEncRootPath, businessUnit)));
 
             A.CallTo(() => fakefileShareService.GetBatchInfoBasedOnProducts(A<List<Products>>.Ignored, A<SalesCatalogueServiceResponseQueueMessage>.Ignored, A<CancellationTokenSource>.Ignored, A<CancellationToken>.Ignored, A<string>.Ignored, A<string>.Ignored)).MustNotHaveHappened();
         }

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/Services/FulfilmentSalesCatalogueServiceTest.cs
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/Services/FulfilmentSalesCatalogueServiceTest.cs
@@ -54,11 +54,11 @@ namespace UKHO.ExchangeSetService.Webjob.UnitTests.Services
             var response = await _fulfilmentSalesCatalogueService.GetSalesCatalogueDataResponse(FakeBatchId, null);
 
             Assert.That(response, Is.Not.Null);
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(response.ResponseCode, Is.EqualTo(HttpStatusCode.OK));
                 Assert.That(response, Is.InstanceOf(typeof(SalesCatalogueDataResponse)));
-            });
+            }
         }
     }
 }

--- a/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/UKHO.ExchangeSetService.Webjob.UnitTests.csproj
+++ b/UKHO.ExchangeSetService.API/UKHO.ExchangeSetService.Webjob.UnitTests/UKHO.ExchangeSetService.Webjob.UnitTests.csproj
@@ -9,17 +9,17 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
+    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FakeItEasy" Version="8.3.0" />
-    <PackageReference Include="NUnit" Version="4.5.1" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.12.0">
+    <PackageReference Include="FakeItEasy" Version="9.0.1" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
#### PR Classification
Test infrastructure and code modernization to support updated test libraries and improve assertion patterns.

#### PR Summary
This pull request upgrades test dependencies and refactors test code for compatibility with newer versions of NUnit and related libraries, ensuring future maintainability and reliability of the test suite.
- All test projects: Upgraded coverlet.msbuild, FakeItEasy, NUnit, NUnit.Analyzers, and NUnit3TestAdapter to latest versions.
- Test files: Replaced `Assert.Multiple(() => { ... })` with `using (Assert.EnterMultipleScope()) { ... }` for multiple assertions.
- Test files: Updated `Assert.ThrowsAsync` and `Assert.Throws` calls to use explicit `Func<Task>` or `Action` casting.
- Test files: Minor formatting and using directive cleanups for consistency.
- No changes to production code; all updates are limited to test code and configuration.
